### PR TITLE
feat: Support Lambda Extension for ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ custom:
 
 Enables logging. Defaults to `false`
 
+#### `enableExtension` (optional)
+
+Allows your function to deliver its telemetry to New Relic via AWS Lambda Extension. Can be used with the `enableIntegration` option--they're not mutually exclusive. Defaults to `false`
+
+```yaml
+custom:
+  newRelic:
+    enableExtension: true
+```
 #### `enableIntegration` (optional)
 
 Allows the creation of New Relic aws cloud integration when absent. Defaults to `false`
@@ -232,7 +241,7 @@ ingestion function. See the [aws-log-ingestion documentation](https://github.com
 
 #### `prepend` (optional)
 
-Whether or not to prepend the IOpipe layer. Defaults to `false` which appends the layer.
+Whether or not to prepend the New Relic layer. Defaults to `false` which appends the layer.
 
 ```yaml
 custom:

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [
     "dist",
     "package.json",
     "README.md",
-	"templates"
+    "templates"
   ],
   "scripts": {
     "build": "rm -rf dist && tsc",

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,7 @@ export default class NewRelicLambdaLayerPlugin {
       return;
     }
 
-    if (this.config.enableExtension) {
+    if (this.config.enableExtension && this.licenseKey) {
       this.serverless.cli.log(
         "Log ingestion will be via Lambda Extension; skipping log subscription."
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import * as _ from "lodash";
 import * as path from "path";
 import * as request from "request-promise-native";
 import * as semver from "semver";
-import * as util from "util";
 // tslint:disable-next-line
 import * as Serverless from "serverless";
 import { fetchLicenseKey, nerdgraphFetch } from "./api";
@@ -25,6 +24,8 @@ export default class NewRelicLambdaLayerPlugin {
   public hooks: {
     [event: string]: Promise<any>;
   };
+  public licenseKey: string;
+  public managedSecretConfigured: boolean;
 
   constructor(serverless: Serverless, options: Serverless.Options) {
     this.serverless = serverless;
@@ -35,6 +36,8 @@ export default class NewRelicLambdaLayerPlugin {
       "provider.region",
       "us-east-1"
     );
+    this.licenseKey = null;
+    this.managedSecretConfigured = false;
 
     this.hooks = this.shouldSkipPlugin()
       ? {}
@@ -84,6 +87,16 @@ export default class NewRelicLambdaLayerPlugin {
     return new Integration(this).check();
   }
 
+  public async configureLicenseForExtension() {
+    if (!this.licenseKey) {
+      this.licenseKey = await this.retrieveLicenseKey();
+    }
+    const managedSecret = await new Integration(this).createManagedSecret();
+    if (managedSecret) {
+      this.managedSecretConfigured = true;
+    }
+  }
+
   public async run() {
     const version = this.serverless.getVersion();
     if (semver.lt(version, "1.34.0")) {
@@ -116,6 +129,12 @@ export default class NewRelicLambdaLayerPlugin {
       return;
     }
 
+    if (this.config.enableExtension) {
+      // If using the extension, try to store the NR license key in a managed secret
+      // for the extension to authenticate. If not, fall back to function environment variable
+      await this.configureLicenseForExtension();
+    }
+
     const funcs = this.functions;
     const promises = [];
 
@@ -135,6 +154,13 @@ export default class NewRelicLambdaLayerPlugin {
     if (this.autoSubscriptionDisabled) {
       this.serverless.cli.log(
         "Skipping adding log subscription. Explicitly disabled"
+      );
+      return;
+    }
+
+    if (this.config.enableExtension) {
+      this.serverless.cli.log(
+        "Log ingestion will be via Lambda Extension; skipping log subscription."
       );
       return;
     }
@@ -222,8 +248,7 @@ export default class NewRelicLambdaLayerPlugin {
       return;
     }
 
-    if (
-      typeof runtime !== "string" ||
+    const wrappableRuntime =
       [
         "nodejs10.x",
         "nodejs12.x",
@@ -232,7 +257,11 @@ export default class NewRelicLambdaLayerPlugin {
         "python3.6",
         "python3.7",
         "python3.8"
-      ].indexOf(runtime) === -1
+      ].indexOf(runtime) === -1;
+
+    if (
+      typeof runtime !== "string" ||
+      (wrappableRuntime && !this.config.enableExtension)
     ) {
       this.serverless.cli.log(
         `Unsupported runtime "${runtime}" for NewRelic layer; skipping.`
@@ -293,6 +322,13 @@ export default class NewRelicLambdaLayerPlugin {
 
     if (runtime.match("python")) {
       environment.NEW_RELIC_SERVERLESS_MODE_ENABLED = "true";
+    }
+
+    if (this.config.enableExtension) {
+      environment.NEW_RELIC_LAMBDA_EXTENSION_ENABLED = "true";
+      if (!this.managedSecretConfigured && this.licenseKey) {
+        environment.NEW_RELIC_LICENSE_KEY = this.licenseKey;
+      }
     }
 
     funcDef.environment = environment;
@@ -583,17 +619,25 @@ export default class NewRelicLambdaLayerPlugin {
     }
   }
 
-  private async formatFunctionVariables() {
-    const { logEnabled, apiKey, accountId } = this.config;
+  private async retrieveLicenseKey() {
+    const { apiKey, accountId } = this.config;
     const userData = await nerdgraphFetch(
       apiKey,
       this.region,
       fetchLicenseKey(accountId)
     );
-    const { licenseKey } = _.get(userData, "data.actor.account", null);
+    this.licenseKey = _.get(userData, "data.actor.account.licenseKey", null);
+    return this.licenseKey;
+  }
+
+  private async formatFunctionVariables() {
+    const { logEnabled } = this.config;
+    const licenseKey = this.licenseKey
+      ? this.licenseKey
+      : await this.retrieveLicenseKey();
     const loggingVar = logEnabled ? "True" : "False";
 
-    const parameters = [
+    return [
       {
         ParameterKey: "NRLoggingEnabled",
         ParameterValue: `${loggingVar}`
@@ -603,7 +647,6 @@ export default class NewRelicLambdaLayerPlugin {
         ParameterValue: `${licenseKey}`
       }
     ];
-    return parameters;
   }
 
   private async getSarTemplate() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,13 +158,6 @@ export default class NewRelicLambdaLayerPlugin {
       return;
     }
 
-    if (this.config.enableExtension && this.licenseKey) {
-      this.serverless.cli.log(
-        "Log ingestion will be via Lambda Extension; skipping log subscription."
-      );
-      return;
-    }
-
     const funcs = this.functions;
     let { cloudWatchFilter = [...DEFAULT_FILTER_PATTERNS] } = this.config;
 

--- a/templates/nr-license-key-secret.yaml
+++ b/templates/nr-license-key-secret.yaml
@@ -1,0 +1,57 @@
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  LicenseKey:
+    Type: String
+    Description: The New Relic account license key
+    AllowedPattern: '(?:eu-)?[0-9a-f]+(?:[A-Z]{4})?'
+    NoEcho: true
+  SecretName:
+    Type: String
+    Description: The friendly name for the license key secret
+    Default: NEW_RELIC_LICENSE_KEY
+  PolicyName:
+    Type: String
+    Description: Policy name of the policy to use to allow access to the license key secret.
+    Default: NewRelic-ViewLicenseKey
+  LicenseKeySecretExportName:
+    Type: String
+    Default: NewRelic-LicenseKeySecretARN
+  ViewPolicyExportName:
+    Type: String
+    Default: NewRelic-ViewLicenseKeyPolicyARN
+  Region:
+    Type: String
+    Default: 'us-east-2'
+
+Resources:
+  LicenseKeySecret:
+    Type: 'AWS::SecretsManager::Secret'
+    Properties:
+      Description: The New Relic license key, for sending telemetry
+      Name: !Sub "${SecretName}"
+      SecretString: !Sub '{ "LicenseKey": "${LicenseKey}" }'
+  ViewNewRelicLicenseKeyPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      ManagedPolicyName: !Sub
+        - ${PolicyName}-${Region}
+        - { PolicyName: !Ref PolicyName, Region: !Ref Region }
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - 'secretsmanager:GetSecretValue'
+            Resource: !Ref LicenseKeySecret
+
+Outputs:
+  LicenseKeySecretARN:
+    Description: The ARN of the LicenseKey Secret
+    Value: !Ref LicenseKeySecret
+    Export:
+      Name: !Sub "${AWS::StackName}-${LicenseKeySecretExportName}"
+  ViewPolicyARN:
+    Description: The ARN of the LicenseKey Secret's view policy
+    Value: !Ref ViewNewRelicLicenseKeyPolicy
+    Export:
+      Name: !Sub "${AWS::StackName}-${ViewPolicyExportName}"

--- a/templates/nr-license-key-secret.yaml
+++ b/templates/nr-license-key-secret.yaml
@@ -21,7 +21,6 @@ Parameters:
     Default: NewRelic-ViewLicenseKeyPolicyARN
   Region:
     Type: String
-    Default: 'us-east-2'
 
 Resources:
   LicenseKeySecret:

--- a/tests/fixtures/debug-log-level.output.service.json
+++ b/tests/fixtures/debug-log-level.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -53,7 +53,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:20"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:24"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -75,7 +75,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/debug.output.service.json
+++ b/tests/fixtures/debug.output.service.json
@@ -30,7 +30,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -52,7 +52,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:20"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:24"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -74,7 +74,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/include.output.service.json
+++ b/tests/fixtures/include.output.service.json
@@ -29,7 +29,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/log-disabled.output.service.json
+++ b/tests/fixtures/log-disabled.output.service.json
@@ -30,7 +30,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -49,7 +49,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:20"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:24"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -68,7 +68,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/log-level.output.service.json
+++ b/tests/fixtures/log-level.output.service.json
@@ -30,7 +30,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -52,7 +52,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:20"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:24"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -74,7 +74,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment-log-level.output.service.json
+++ b/tests/fixtures/provider-environment-log-level.output.service.json
@@ -33,7 +33,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -55,7 +55,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:20"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:24"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -77,7 +77,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment.output.service.json
+++ b/tests/fixtures/provider-environment.output.service.json
@@ -32,7 +32,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -54,7 +54,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:20"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:24"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -76,7 +76,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/stage-included.output.service.json
+++ b/tests/fixtures/stage-included.output.service.json
@@ -29,7 +29,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -48,7 +48,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:20"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:24"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -67,7 +67,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],


### PR DESCRIPTION
Adding the option of supporting the Lambda extension for sending telemetry as an alternative to CW log subscriptions.

If `enableExtension` is true and the `apiKey` is set (and valid), the plugin stores the NR license key in a managed secret, if the secret doesn't already exist. If it doesn't exist and can't be created, the plugin falls back to setting the license key as a function environment variable. If there's no license key set, the plugin falls back to CW log subscription. 