### PR TITLE
fix: Add access policy to execution role

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -40,15 +40,13 @@ const buildTestCases = () => {
       split(".")
     )
   )(testCaseFiles);
-  const testCases = map((caseName: string) => {
+  return map((caseName: string) => {
     const testCaseContents = testCaseContentsFromFiles(
       testCaseFilesByName[caseName]
     );
 
     return { ...testCaseContents, caseName };
   }, Object.keys(testCaseFilesByName));
-
-  return testCases;
 };
 
 describe("NewRelicLambdaLayerPlugin", () => {
@@ -65,10 +63,14 @@ describe("NewRelicLambdaLayerPlugin", () => {
         serverless.setProvider("aws", new AwsProvider(serverless, options));
         const plugin = new NewRelicLambdaLayerPlugin(serverless, options);
 
+        // mock API-calling methods that would cause timeout...
+        plugin.checkForSecretPolicy = jest.fn(() => {});
+        plugin.regionPolicyValid = jest.fn(() => true);
+        plugin.configureLicenseForExtension = jest.fn(() => {});
+
         try {
           await plugin.hooks['before:deploy:function:packageFunction']();
         } catch (err) {}
-        
 
         expect(
           omit(


### PR DESCRIPTION
On deploy, this version of the plugin checks for the existence of a secret access policy named with the current region. If found, it provides the policy ARN to serverless's generated CF template as a ManagedPolicyArn, so that the function can access the license key secret for authenticating the extension.

If the policy is not found for the function's region, the plugin creates the secret and policy. If the license key isn't found, the plugin falls back to ingestion via the ingestion lambda and CloudWatch Log Subscription.