### PR TITLE
chore: converting accountId to number before comparing to integrated accounts in NR

### DIFF
--- a/src/integration.ts
+++ b/src/integration.ts
@@ -46,7 +46,7 @@ export default class Integration {
       return (
         account.name === linkedAccount &&
         account.externalId === externalId &&
-        account.nrAccountId === accountId
+        account.nrAccountId === parseInt(accountId, 10)
       );
     });
 
@@ -210,9 +210,7 @@ export default class Integration {
       );
     } catch (err) {
       this.serverless.cli.log(
-        `Error while creating the New Relic AWS Lambda cloud integration: ${JSON.stringify(
-          err
-        )}.`
+        `Error while creating the New Relic AWS Lambda cloud integration: ${err}.`
       );
     }
   }


### PR DESCRIPTION
When passing accountId as an env var it wasn't properly being compared to the returned account id from the graphql integration check because of strict equality comparing numbers to strings. 

https://newrelic.atlassian.net/browse/LAMBDA-1083
