### PR TITLE
feat: Add 'proxy' option in order to allow this plugin to work behind an HTTP proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,16 @@ custom:
     javaNewRelicHandler: handleStreamsRequest
 ```
 
+#### `proxy` (optional)
+
+This plugin makes various HTTP requests to public APIs in order to retrieve data about the New Relic and cloud provider accounts. If you are behind a proxy when this plugin runs, the HTTP agent needs the proxy information to connect to those APIs. Use the given URL as a proxy for HTTP requests.
+
+```yaml
+custom:
+  newRelic:
+    proxy: http://yourproxy.com:8080
+```
+
 ## Supported Runtimes
 
 This plugin currently supports the following AWS runtimes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "fs-extra": "^9.1.0",
+        "https-proxy-agent": "^5.0.0",
         "lodash": "^4.17.20",
         "node-fetch": "^2.6.1",
         "path": "^0.12.7",
@@ -2168,7 +2169,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -3797,7 +3797,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -5912,9 +5911,9 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "dev": true,
+      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha1-4qkFQqu2inYuCghQ9sntrf2FBrI=",
+      "license": "MIT",
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -8961,8 +8960,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
@@ -15633,7 +15631,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "requires": {
         "debug": "4"
       }
@@ -16988,7 +16985,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -18713,9 +18709,8 @@
     },
     "https-proxy-agent": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "dev": true,
+      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha1-4qkFQqu2inYuCghQ9sntrf2FBrI=",
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -21251,8 +21246,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mute-stream": {
       "version": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "fs-extra": "^9.1.0",
+    "https-proxy-agent": "^5.0.0",
     "lodash": "^4.17.20",
     "node-fetch": "^2.6.1",
     "path": "^0.12.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,16 +1,22 @@
+import { HttpsProxyAgent } from "https-proxy-agent";
 import fetch from "node-fetch";
 
 export const nerdgraphFetch = async (
   apiKey: string,
   region: string,
-  query: string
+  query: string,
+  proxy?: string
 ) => {
   const gqlUrl =
     region === "eu"
       ? "https://api.eu.newrelic.com/graphql"
       : "https://api.newrelic.com/graphql";
 
+  const agent =
+    typeof proxy === "undefined" ? null : new HttpsProxyAgent(proxy);
+
   const res = await fetch(gqlUrl, {
+    agent,
     body: JSON.stringify({ query }),
     headers: {
       "API-Key": apiKey,

--- a/src/index.ts
+++ b/src/index.ts
@@ -763,11 +763,12 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
   }
 
   private async retrieveLicenseKey() {
-    const { apiKey, accountId, nrRegion } = this.config;
+    const { apiKey, accountId, nrRegion, proxy } = this.config;
     const userData = await nerdgraphFetch(
       apiKey,
       nrRegion,
-      fetchLicenseKey(accountId)
+      fetchLicenseKey(accountId),
+      proxy
     );
     this.licenseKey = _.get(userData, "data.actor.account.licenseKey", null);
     return this.licenseKey;

--- a/src/index.ts
+++ b/src/index.ts
@@ -250,6 +250,10 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
       await this.configureLicenseForExtension();
     }
 
+    if (this.config.proxy) {
+      this.serverless.cli.log(`HTTP proxy set to ${this.config.proxy}`);
+    }
+
     if (!this.licenseKeySecretDisabled) {
       // before adding layer, attach secret access policy
       // to each function's execution role:

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -23,7 +23,13 @@ export default class Integration {
   }
 
   public async check() {
-    const { accountId, enableIntegration, apiKey, nrRegion } = this.config;
+    const {
+      accountId,
+      enableIntegration,
+      apiKey,
+      nrRegion,
+      proxy
+    } = this.config;
     const {
       linkedAccount = `New Relic Lambda Integration - ${accountId}`
     } = this.config;
@@ -31,7 +37,8 @@ export default class Integration {
     const integrationData = await nerdgraphFetch(
       apiKey,
       nrRegion,
-      fetchLinkedAccounts(accountId)
+      fetchLinkedAccounts(accountId),
+      proxy
     );
 
     const linkedAccounts = _.get(
@@ -158,7 +165,7 @@ export default class Integration {
         return;
       }
 
-      const { accountId, apiKey, nrRegion } = this.config;
+      const { accountId, apiKey, nrRegion, proxy } = this.config;
       const {
         linkedAccount = `New Relic Lambda Integration - ${accountId}`
       } = this.config;
@@ -170,7 +177,8 @@ export default class Integration {
       const res = await nerdgraphFetch(
         apiKey,
         nrRegion,
-        cloudLinkAccountMutation(accountId, roleArn, linkedAccount)
+        cloudLinkAccountMutation(accountId, roleArn, linkedAccount),
+        proxy
       );
 
       const { linkedAccounts, errors } = _.get(res, "data.cloudLinkAccount", {
@@ -190,7 +198,8 @@ export default class Integration {
           "aws",
           "lambda",
           linkedAccountId
-        )
+        ),
+        proxy
       );
 
       const { errors: integrationErrors } = _.get(

--- a/tests/fixtures/debug-log-level.output.service.json
+++ b/tests/fixtures/debug-log-level.output.service.json
@@ -32,7 +32,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -55,7 +55,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:47"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -78,7 +78,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -101,7 +101,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:15"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/debug.output.service.json
+++ b/tests/fixtures/debug.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -54,7 +54,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:47"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -77,7 +77,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -100,7 +100,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:15"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/distributed-tracing-enabled.output.service.json
+++ b/tests/fixtures/distributed-tracing-enabled.output.service.json
@@ -28,7 +28,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:47"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -53,7 +53,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -78,7 +78,7 @@
       ],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/eu.output.service.json
+++ b/tests/fixtures/eu.output.service.json
@@ -30,7 +30,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:47"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -57,7 +57,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -84,7 +84,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:15"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -111,7 +111,7 @@
       ],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/include.output.service.json
+++ b/tests/fixtures/include.output.service.json
@@ -30,7 +30,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/lambda-extension-disabled.output.service.json
+++ b/tests/fixtures/lambda-extension-disabled.output.service.json
@@ -25,7 +25,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:47"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -49,7 +49,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -73,7 +73,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:15"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -97,7 +97,7 @@
       ],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/lambda-extension-enabled.output.service.json
+++ b/tests/fixtures/lambda-extension-enabled.output.service.json
@@ -26,7 +26,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:47"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -50,7 +50,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -74,7 +74,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:15"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -98,7 +98,7 @@
       ],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/license-key-secret-disabled.output.service.json
+++ b/tests/fixtures/license-key-secret-disabled.output.service.json
@@ -27,7 +27,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:47"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -51,7 +51,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -75,7 +75,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:15"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -99,7 +99,7 @@
       ],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/log-disabled.output.service.json
+++ b/tests/fixtures/log-disabled.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -51,7 +51,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:47"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -71,7 +71,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -91,7 +91,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:15"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/log-ingestion-via-extension.output.service.json
+++ b/tests/fixtures/log-ingestion-via-extension.output.service.json
@@ -26,7 +26,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:47"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -47,7 +47,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -68,7 +68,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:15"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -89,7 +89,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/log-level.output.service.json
+++ b/tests/fixtures/log-level.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -54,7 +54,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:47"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -77,7 +77,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -100,7 +100,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:15"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment-log-level.output.service.json
+++ b/tests/fixtures/provider-environment-log-level.output.service.json
@@ -34,7 +34,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -57,7 +57,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:47"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -80,7 +80,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -103,7 +103,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:15"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment.output.service.json
+++ b/tests/fixtures/provider-environment.output.service.json
@@ -33,7 +33,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -56,7 +56,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:47"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -79,7 +79,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -102,7 +102,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:15"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/proxy.input.service.json
+++ b/tests/fixtures/proxy.input.service.json
@@ -1,0 +1,53 @@
+{
+  "service": "newrelic-lambda-layers-nodejs-example",
+  "provider": {
+    "name": "aws",
+    "stage": "prod",
+    "region": "us-east-1",
+    "stackTags": {
+      "environment": "us-testing",
+      "owning_team": "LAMBDA",
+      "product": "aws-lambda"
+    },
+    "tags": {
+      "environment": "us-testing",
+      "owning_team": "LAMBDA",
+      "product": "aws-lambda"
+    }
+  },
+  "plugins": ["serverless-newrelic-lambda-layers"],
+  "custom": {
+    "newRelic": {
+      "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
+      "apiKey": "${env:NEW_RELIC_PERSONAL_API_KEY}",
+      "enableExtension": true,
+      "proxy": "http://myproxy.com:8080"
+    }
+  },
+  "functions": {
+    "layer-nodejs810": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs8.10"
+    },
+    "layer-nodejs10x": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs10.x"
+    },
+    "layer-nodejs12x": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs12.x"
+    },
+    "layer-nodejs14x": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs14.x"
+    }
+  }
+}

--- a/tests/fixtures/proxy.output.service.json
+++ b/tests/fixtures/proxy.output.service.json
@@ -1,0 +1,111 @@
+{
+  "configValidationMode": "warn",
+  "custom": {
+    "newRelic": {
+      "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
+      "apiKey": "${env:NEW_RELIC_PERSONAL_API_KEY}",
+      "enableExtension": true,
+      "proxy": "http://myproxy.com:8080"
+    }
+  },
+  "disabledDeprecations": [],
+  "functions": {
+    "layer-nodejs10x": {
+      "environment": {
+        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
+        "NEW_RELIC_APP_NAME": "layer-nodejs10x",
+        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
+        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
+        "NEW_RELIC_NO_CONFIG_FILE": "true",
+        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
+      },
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "newrelic-lambda-wrapper.handler",
+      "layers": [
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
+      ],
+      "package": {
+        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
+        "include": ["handler.js"]
+      },
+      "runtime": "nodejs10.x"
+    },
+    "layer-nodejs12x": {
+      "environment": {
+        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
+        "NEW_RELIC_APP_NAME": "layer-nodejs12x",
+        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
+        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
+        "NEW_RELIC_NO_CONFIG_FILE": "true",
+        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
+      },
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "newrelic-lambda-wrapper.handler",
+      "layers": [
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
+      ],
+      "package": {
+        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
+        "include": ["handler.js"]
+      },
+      "runtime": "nodejs12.x"
+    },
+    "layer-nodejs14x": {
+      "environment": {
+        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
+        "NEW_RELIC_APP_NAME": "layer-nodejs14x",
+        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
+        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
+        "NEW_RELIC_NO_CONFIG_FILE": "true",
+        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
+      },
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "newrelic-lambda-wrapper.handler",
+      "layers": [
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
+      ],
+      "package": {
+        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
+        "include": ["handler.js"]
+      },
+      "runtime": "nodejs14.x"
+    },
+    "layer-nodejs810": {
+      "environment": {
+        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
+        "NEW_RELIC_APP_NAME": "layer-nodejs810",
+        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
+        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
+        "NEW_RELIC_NO_CONFIG_FILE": "true",
+        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
+      },
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "newrelic-wrapper-helper.handler",
+      "layers": [
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
+      ],
+      "package": {
+        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
+        "include": ["handler.js"]
+      },
+      "runtime": "nodejs8.10"
+    }
+  },
+  "plugins": ["serverless-newrelic-lambda-layers"],
+  "provider": {
+    "name": "aws",
+    "region": "us-east-1",
+    "stackTags": {
+      "environment": "us-testing",
+      "owning_team": "LAMBDA",
+      "product": "aws-lambda"
+    },
+    "stage": "prod",
+    "tags": {
+      "environment": "us-testing",
+      "owning_team": "LAMBDA",
+      "product": "aws-lambda"
+    }
+  },
+  "service": "newrelic-lambda-layers-nodejs-example"
+}

--- a/tests/fixtures/stage-included.output.service.json
+++ b/tests/fixtures/stage-included.output.service.json
@@ -30,7 +30,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-wrapper-helper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -50,7 +50,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:47"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -70,7 +70,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -90,7 +90,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:15"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "allowSyntheticDefaultImports": true,
         "module": "commonjs",
         "outDir": "dist",
         "target": "es6"


### PR DESCRIPTION
Resolves #143.

## Description
Add a configuration option to set a network request proxy so that HTTP requests from the plugin work when behind a proxy. 

## Justification
Many businesses operate behind a web proxy to control and monitor internet access. Those businesses can not use the latest versions of the plugin without the ability to navigate a proxy.

## Comments
I looked into setting this without using a new dependency, but judged that it was more hassle than it was worth to configure an HTTP proxy using the low-level NodeJS HTTP Agent. The [node-https-proxy-agent](https://github.com/TooTallNate/node-https-proxy-agent) package is the commonly referenced way to configure a proxy with `node-fetch`.
