### PR TITLE
Remove support for node 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,11 +62,7 @@ typings/
 
 dist/
 .env
-/.idea/.gitignore
-/.idea/mainland-layer.iml
-/.idea/misc.xml
-/.idea/modules.xml
-/.idea/vcs.xml
+.idea/
 
 .DS_Store
 example.service.input.json

--- a/README.md
+++ b/README.md
@@ -330,7 +330,6 @@ custom:
 
 This plugin currently supports the following AWS runtimes:
 
-- nodejs8.10
 - nodejs10.x
 - nodejs12.x
 - nodejs14.x

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ This plugin currently supports the following AWS runtimes:
 - python3.6
 - python3.7
 - python3.8
+- python3.9
 - java11
 - java8.al2
 

--- a/examples/nodejs/serverless.yml
+++ b/examples/nodejs/serverless.yml
@@ -23,17 +23,6 @@ custom:
     logLevel: debug
 
 functions:
-  layer-nodejs810:
-    events:
-      - schedule: rate(5 minutes)
-    handler: handler.handler
-    package:
-      exclude:
-        - ./**
-      include:
-        - handler.js
-    runtime: nodejs8.10
-
   layer-nodejs10x:
     events:
       - schedule: rate(5 minutes)

--- a/examples/python/serverless.yml
+++ b/examples/python/serverless.yml
@@ -66,3 +66,14 @@ functions:
       include:
         - handler.py
     runtime: python3.8
+
+  layer-python39:
+    events:
+      - schedule: rate(5 minutes)
+    handler: handler.handler
+    package:
+      exclude:
+        - ./**
+      include:
+        - handler.py
+    runtime: python3.9

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "1.1.8",
+  "version": "2.0.0",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -382,7 +382,6 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
         "nodejs10.x",
         "nodejs12.x",
         "nodejs14.x",
-        "nodejs8.10",
         "python2.7",
         "python3.6",
         "python3.7",
@@ -553,11 +552,6 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
   private getHandlerWrapper(runtime: string, handler: string) {
     if (["nodejs10.x", "nodejs12.x", "nodejs14.x"].indexOf(runtime) !== -1) {
       return "newrelic-lambda-wrapper.handler";
-    }
-
-    if (runtime === "nodejs8.10") {
-      this.addNodeHelper();
-      return "newrelic-wrapper-helper.handler";
     }
 
     if (runtime.match("python")) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -387,6 +387,7 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
         "python3.6",
         "python3.7",
         "python3.8",
+        "python3.9",
         "java11",
         "java8.al2"
       ].indexOf(runtime) === -1;

--- a/tests/fixtures/debug-log-level.input.service.json
+++ b/tests/fixtures/debug-log-level.input.service.json
@@ -27,15 +27,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs8.10",
-      "environment": {
-        "NEW_RELIC_LOG_LEVEL": "debug"
-      }
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/debug-log-level.output.service.json
+++ b/tests/fixtures/debug-log-level.output.service.json
@@ -28,29 +28,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-wrapper-helper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs8.10",
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs810",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_LOG": "stdout",
-        "NEW_RELIC_LOG_LEVEL": "debug",
-        "NEW_RELIC_LOG_ENABLED": "true",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",

--- a/tests/fixtures/debug-log-level.output.service.json
+++ b/tests/fixtures/debug-log-level.output.service.json
@@ -55,7 +55,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -78,7 +78,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -101,7 +101,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/debug.input.service.json
+++ b/tests/fixtures/debug.input.service.json
@@ -26,15 +26,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs8.10",
-      "environment": {
-        "NEW_RELIC_LOG_LEVEL": "error"
-      }
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/debug.output.service.json
+++ b/tests/fixtures/debug.output.service.json
@@ -54,7 +54,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -77,7 +77,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -100,7 +100,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/debug.output.service.json
+++ b/tests/fixtures/debug.output.service.json
@@ -27,29 +27,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-wrapper-helper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs8.10",
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs810",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_LOG": "stdout",
-        "NEW_RELIC_LOG_LEVEL": "error",
-        "NEW_RELIC_LOG_ENABLED": "true",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",

--- a/tests/fixtures/distributed-tracing-enabled.input.service.json
+++ b/tests/fixtures/distributed-tracing-enabled.input.service.json
@@ -25,12 +25,6 @@
     }
   },
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs8.10"
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/distributed-tracing-enabled.output.service.json
+++ b/tests/fixtures/distributed-tracing-enabled.output.service.json
@@ -28,7 +28,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -53,7 +53,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/distributed-tracing-enabled.output.service.json
+++ b/tests/fixtures/distributed-tracing-enabled.output.service.json
@@ -60,31 +60,6 @@
         "include": ["handler.js"]
       },
       "runtime": "nodejs12.x"
-    },
-    "layer-nodejs810": {
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs810",
-        "NEW_RELIC_DISTRIBUTED_TRACING_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      },
-      "events": [
-        {
-          "schedule": "rate(5 minutes)"
-        }
-      ],
-      "handler": "newrelic-wrapper-helper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs8.10"
     }
   },
   "plugins": ["serverless-newrelic-lambda-layers"],

--- a/tests/fixtures/eu.input.service.json
+++ b/tests/fixtures/eu.input.service.json
@@ -27,15 +27,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs8.10",
-      "environment": {
-        "NEW_RELIC_LOG_LEVEL": "error"
-      }
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/eu.output.service.json
+++ b/tests/fixtures/eu.output.service.json
@@ -30,7 +30,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -57,7 +57,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -84,7 +84,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/eu.output.service.json
+++ b/tests/fixtures/eu.output.service.json
@@ -91,33 +91,6 @@
         "include": ["handler.js"]
       },
       "runtime": "nodejs14.x"
-    },
-    "layer-nodejs810": {
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs810",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_LOG": "stdout",
-        "NEW_RELIC_LOG_ENABLED": "true",
-        "NEW_RELIC_LOG_LEVEL": "error",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      },
-      "events": [
-        {
-          "schedule": "rate(5 minutes)"
-        }
-      ],
-      "handler": "newrelic-wrapper-helper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs8.10"
     }
   },
   "plugins": ["serverless-newrelic-lambda-layers"],

--- a/tests/fixtures/include-exclude.input.service.json
+++ b/tests/fixtures/include-exclude.input.service.json
@@ -21,18 +21,12 @@
     "newRelic": {
       "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
       "enableExtension": true,
-      "include": ["layer-nodejs810"],
+      "include": ["layer-nodejs10x"],
       "exclude": ["layer-nodejs12x"]
     }
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs8.10"
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/include-exclude.output.service.json
+++ b/tests/fixtures/include-exclude.output.service.json
@@ -21,18 +21,12 @@
     "newRelic": {
       "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
       "enableExtension": true,
-      "include": ["layer-nodejs810"],
+      "include": ["layer-nodejs10x"],
       "exclude": ["layer-nodejs12x"]
     }
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs8.10"
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/include.input.service.json
+++ b/tests/fixtures/include.input.service.json
@@ -20,17 +20,11 @@
   "custom": {
     "newRelic": {
       "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
-      "include": ["layer-nodejs810"]
+      "include": ["layer-nodejs10x"]
     }
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs8.10"
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/include.output.service.json
+++ b/tests/fixtures/include.output.service.json
@@ -21,35 +21,27 @@
     "newRelic": {
       "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
       "enableExtension": true,
-      "include": ["layer-nodejs810"]
+      "include": ["layer-nodejs10x"]
     }
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-wrapper-helper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs8.10",
+    "layer-nodejs10x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs810",
+        "NEW_RELIC_APP_NAME": "layer-nodejs10x",
         "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
-    },
-    "layer-nodejs10x": {
+       },
+
       "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "handler": "newrelic-lambda-wrapper.handler",
+      "layers": [
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
+      ],
+      "package": { "exclude": ["./**", "!newrelic-wrapper-helper.js"], "include": ["handler.js"] },
       "runtime": "nodejs10.x"
     },
     "layer-nodejs12x": {

--- a/tests/fixtures/lambda-extension-disabled.input.service.json
+++ b/tests/fixtures/lambda-extension-disabled.input.service.json
@@ -24,12 +24,6 @@
     }
   },
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs8.10"
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/lambda-extension-disabled.output.service.json
+++ b/tests/fixtures/lambda-extension-disabled.output.service.json
@@ -80,30 +80,6 @@
         "include": ["handler.js"]
       },
       "runtime": "nodejs14.x"
-    },
-    "layer-nodejs810": {
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs810",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "false",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      },
-      "events": [
-        {
-          "schedule": "rate(5 minutes)"
-        }
-      ],
-      "handler": "newrelic-wrapper-helper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs8.10"
     }
   },
   "plugins": ["serverless-newrelic-lambda-layers"],

--- a/tests/fixtures/lambda-extension-disabled.output.service.json
+++ b/tests/fixtures/lambda-extension-disabled.output.service.json
@@ -25,7 +25,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -49,7 +49,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -73,7 +73,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/lambda-extension-enabled.input.service.json
+++ b/tests/fixtures/lambda-extension-enabled.input.service.json
@@ -24,12 +24,6 @@
     }
   },
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs8.10"
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/lambda-extension-enabled.output.service.json
+++ b/tests/fixtures/lambda-extension-enabled.output.service.json
@@ -81,30 +81,6 @@
         "include": ["handler.js"]
       },
       "runtime": "nodejs14.x"
-    },
-    "layer-nodejs810": {
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs810",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      },
-      "events": [
-        {
-          "schedule": "rate(5 minutes)"
-        }
-      ],
-      "handler": "newrelic-wrapper-helper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs8.10"
     }
   },
   "plugins": ["serverless-newrelic-lambda-layers"],

--- a/tests/fixtures/lambda-extension-enabled.output.service.json
+++ b/tests/fixtures/lambda-extension-enabled.output.service.json
@@ -26,7 +26,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -50,7 +50,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -74,7 +74,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/license-key-secret-disabled.input.service.json
+++ b/tests/fixtures/license-key-secret-disabled.input.service.json
@@ -25,12 +25,6 @@
     }
   },
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs8.10"
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/license-key-secret-disabled.output.service.json
+++ b/tests/fixtures/license-key-secret-disabled.output.service.json
@@ -27,7 +27,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -51,7 +51,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -75,7 +75,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/license-key-secret-disabled.output.service.json
+++ b/tests/fixtures/license-key-secret-disabled.output.service.json
@@ -30,8 +30,13 @@
         "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
       ],
       "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
+        "exclude": [
+          "./**",
+          "!newrelic-wrapper-helper.js"
+        ],
+        "include": [
+          "handler.js"
+        ]
       },
       "runtime": "nodejs10.x"
     },
@@ -54,8 +59,13 @@
         "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
       ],
       "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
+        "exclude": [
+          "./**",
+          "!newrelic-wrapper-helper.js"
+        ],
+        "include": [
+          "handler.js"
+        ]
       },
       "runtime": "nodejs12.x"
     },
@@ -78,34 +88,15 @@
         "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
       ],
       "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
+        "exclude": [
+          "./**",
+          "!newrelic-wrapper-helper.js"
+        ],
+        "include": [
+          "handler.js"
+        ]
       },
       "runtime": "nodejs14.x"
-    },
-    "layer-nodejs810": {
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs810",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      },
-      "events": [
-        {
-          "schedule": "rate(5 minutes)"
-        }
-      ],
-      "handler": "newrelic-wrapper-helper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs8.10"
     }
   },
   "plugins": ["serverless-newrelic-lambda-layers"],

--- a/tests/fixtures/log-disabled.input.service.json
+++ b/tests/fixtures/log-disabled.input.service.json
@@ -26,12 +26,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs8.10"
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/log-disabled.output.service.json
+++ b/tests/fixtures/log-disabled.output.service.json
@@ -27,26 +27,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-wrapper-helper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs8.10",
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs810",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",

--- a/tests/fixtures/log-disabled.output.service.json
+++ b/tests/fixtures/log-disabled.output.service.json
@@ -51,7 +51,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -71,7 +71,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -91,7 +91,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/log-ingestion-via-extension.input.service.json
+++ b/tests/fixtures/log-ingestion-via-extension.input.service.json
@@ -27,12 +27,6 @@
     }
   },
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs8.10"
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/log-ingestion-via-extension.output.service.json
+++ b/tests/fixtures/log-ingestion-via-extension.output.service.json
@@ -23,14 +23,23 @@
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       },
-      "events": [{ "schedule": "rate(5 minutes)" }],
+      "events": [
+        {
+          "schedule": "rate(5 minutes)"
+        }
+      ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
         "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
       ],
       "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
+        "exclude": [
+          "./**",
+          "!newrelic-wrapper-helper.js"
+        ],
+        "include": [
+          "handler.js"
+        ]
       },
       "runtime": "nodejs10.x"
     },
@@ -44,14 +53,23 @@
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       },
-      "events": [{ "schedule": "rate(5 minutes)" }],
+      "events": [
+        {
+          "schedule": "rate(5 minutes)"
+        }
+      ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
         "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
       ],
       "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
+        "exclude": [
+          "./**",
+          "!newrelic-wrapper-helper.js"
+        ],
+        "include": [
+          "handler.js"
+        ]
       },
       "runtime": "nodejs12.x"
     },
@@ -65,37 +83,25 @@
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       },
-      "events": [{ "schedule": "rate(5 minutes)" }],
+      "events": [
+        {
+          "schedule": "rate(5 minutes)"
+        }
+      ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
         "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
       ],
       "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
+        "exclude": [
+          "./**",
+          "!newrelic-wrapper-helper.js"
+        ],
+        "include": [
+          "handler.js"
+        ]
       },
       "runtime": "nodejs14.x"
-    },
-    "layer-nodejs810": {
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs810",
-        "NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS": "true",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      },
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-wrapper-helper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs8.10"
     }
   },
   "plugins": ["serverless-newrelic-lambda-layers"],

--- a/tests/fixtures/log-ingestion-via-extension.output.service.json
+++ b/tests/fixtures/log-ingestion-via-extension.output.service.json
@@ -26,7 +26,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -47,7 +47,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -68,7 +68,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/log-level.input.service.json
+++ b/tests/fixtures/log-level.input.service.json
@@ -26,15 +26,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs8.10",
-      "environment": {
-        "NEW_RELIC_LOG_LEVEL": "debug"
-      }
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/log-level.output.service.json
+++ b/tests/fixtures/log-level.output.service.json
@@ -54,7 +54,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -77,7 +77,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -100,7 +100,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/log-level.output.service.json
+++ b/tests/fixtures/log-level.output.service.json
@@ -27,29 +27,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-wrapper-helper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs8.10",
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs810",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_LOG": "stdout",
-        "NEW_RELIC_LOG_LEVEL": "debug",
-        "NEW_RELIC_LOG_ENABLED": "true",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",

--- a/tests/fixtures/provider-environment-log-level.input.service.json
+++ b/tests/fixtures/provider-environment-log-level.input.service.json
@@ -29,15 +29,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs8.10",
-      "environment": {
-        "NEW_RELIC_LOG_LEVEL": "debug"
-      }
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/provider-environment-log-level.output.service.json
+++ b/tests/fixtures/provider-environment-log-level.output.service.json
@@ -57,7 +57,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -80,7 +80,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -103,7 +103,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment-log-level.output.service.json
+++ b/tests/fixtures/provider-environment-log-level.output.service.json
@@ -30,29 +30,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-wrapper-helper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs8.10",
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs810",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_LOG": "stdout",
-        "NEW_RELIC_LOG_LEVEL": "debug",
-        "NEW_RELIC_LOG_ENABLED": "true",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",

--- a/tests/fixtures/provider-environment.input.service.json
+++ b/tests/fixtures/provider-environment.input.service.json
@@ -28,15 +28,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs8.10",
-      "environment": {
-        "NEW_RELIC_LOG_LEVEL": "debug"
-      }
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/provider-environment.output.service.json
+++ b/tests/fixtures/provider-environment.output.service.json
@@ -56,7 +56,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -79,7 +79,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -102,7 +102,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment.output.service.json
+++ b/tests/fixtures/provider-environment.output.service.json
@@ -29,29 +29,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-wrapper-helper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs8.10",
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs810",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_LOG": "stdout",
-        "NEW_RELIC_LOG_LEVEL": "debug",
-        "NEW_RELIC_LOG_ENABLED": "true",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",

--- a/tests/fixtures/proxy.input.service.json
+++ b/tests/fixtures/proxy.input.service.json
@@ -25,12 +25,6 @@
     }
   },
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs8.10"
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/proxy.output.service.json
+++ b/tests/fixtures/proxy.output.service.json
@@ -22,7 +22,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -42,7 +42,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -62,7 +62,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/proxy.output.service.json
+++ b/tests/fixtures/proxy.output.service.json
@@ -19,14 +19,23 @@
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       },
-      "events": [{ "schedule": "rate(5 minutes)" }],
+      "events": [
+        {
+          "schedule": "rate(5 minutes)"
+        }
+      ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
         "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
       ],
       "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
+        "exclude": [
+          "./**",
+          "!newrelic-wrapper-helper.js"
+        ],
+        "include": [
+          "handler.js"
+        ]
       },
       "runtime": "nodejs10.x"
     },
@@ -39,14 +48,23 @@
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       },
-      "events": [{ "schedule": "rate(5 minutes)" }],
+      "events": [
+        {
+          "schedule": "rate(5 minutes)"
+        }
+      ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
         "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
       ],
       "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
+        "exclude": [
+          "./**",
+          "!newrelic-wrapper-helper.js"
+        ],
+        "include": [
+          "handler.js"
+        ]
       },
       "runtime": "nodejs12.x"
     },
@@ -59,36 +77,25 @@
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       },
-      "events": [{ "schedule": "rate(5 minutes)" }],
+      "events": [
+        {
+          "schedule": "rate(5 minutes)"
+        }
+      ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
         "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
       ],
       "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
+        "exclude": [
+          "./**",
+          "!newrelic-wrapper-helper.js"
+        ],
+        "include": [
+          "handler.js"
+        ]
       },
       "runtime": "nodejs14.x"
-    },
-    "layer-nodejs810": {
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs810",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      },
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-wrapper-helper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs8.10"
     }
   },
   "plugins": ["serverless-newrelic-lambda-layers"],

--- a/tests/fixtures/stage-excluded.input.service.json
+++ b/tests/fixtures/stage-excluded.input.service.json
@@ -25,12 +25,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs8.10"
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/stage-excluded.output.service.json
+++ b/tests/fixtures/stage-excluded.output.service.json
@@ -25,12 +25,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs8.10"
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/stage-included.input.service.json
+++ b/tests/fixtures/stage-included.input.service.json
@@ -25,12 +25,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs8.10"
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/stage-included.output.service.json
+++ b/tests/fixtures/stage-included.output.service.json
@@ -50,7 +50,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:50"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -70,7 +70,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:48"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -90,7 +90,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:18"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/stage-included.output.service.json
+++ b/tests/fixtures/stage-included.output.service.json
@@ -26,26 +26,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs810": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-wrapper-helper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:46"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs8.10",
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs810",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
-    },
     "layer-nodejs10x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",


### PR DESCRIPTION
This shouldn't be merged until after the Python 3.9 PR