### PR TITLE
Improve logging around http calls 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "fs-extra": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,7 +5,8 @@ export const nerdgraphFetch = async (
   apiKey: string,
   region: string,
   query: string,
-  proxy?: string
+  proxy?: string,
+  context?: any
 ) => {
   const gqlUrl =
     region === "eu"
@@ -23,6 +24,10 @@ export const nerdgraphFetch = async (
       "Content-Type": "application/json"
     },
     method: "POST"
+  }).catch(e => {
+    context.serverless.log(`Error fetching from NerdGraph; ${context.caller}`);
+    context.serverless.log.log(e);
+    return null;
   });
   return res.json();
 };

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -38,7 +38,11 @@ export default class Integration {
       apiKey,
       nrRegion,
       fetchLinkedAccounts(accountId),
-      proxy
+      proxy,
+      {
+        caller: "check integration for linked accounts",
+        serverless: this.serverless
+      }
     );
 
     const linkedAccounts = _.get(
@@ -178,7 +182,11 @@ export default class Integration {
         apiKey,
         nrRegion,
         cloudLinkAccountMutation(accountId, roleArn, linkedAccount),
-        proxy
+        proxy,
+        {
+          caller: "enable integration, cloudLinkAccountMutation",
+          serverless: this.serverless
+        }
       );
 
       const { linkedAccounts, errors } = _.get(res, "data.cloudLinkAccount", {
@@ -199,7 +207,11 @@ export default class Integration {
           "lambda",
           linkedAccountId
         ),
-        proxy
+        proxy,
+        {
+          caller: "enable integration, cloudServiceIntegrationMutation",
+          serverless: this.serverless
+        }
       );
 
       const { errors: integrationErrors } = _.get(

--- a/tests/fixtures/debug-log-level.output.service.json
+++ b/tests/fixtures/debug-log-level.output.service.json
@@ -32,7 +32,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:54"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -55,7 +55,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:52"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -78,7 +78,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/debug.output.service.json
+++ b/tests/fixtures/debug.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:54"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -54,7 +54,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:52"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -77,7 +77,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/distributed-tracing-enabled.output.service.json
+++ b/tests/fixtures/distributed-tracing-enabled.output.service.json
@@ -28,7 +28,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:54"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -53,7 +53,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:52"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/eu.output.service.json
+++ b/tests/fixtures/eu.output.service.json
@@ -30,7 +30,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:54"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -57,7 +57,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:52"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -84,7 +84,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/include.output.service.json
+++ b/tests/fixtures/include.output.service.json
@@ -39,7 +39,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:54"
       ],
       "package": { "exclude": ["./**", "!newrelic-wrapper-helper.js"], "include": ["handler.js"] },
       "runtime": "nodejs10.x"

--- a/tests/fixtures/lambda-extension-disabled.output.service.json
+++ b/tests/fixtures/lambda-extension-disabled.output.service.json
@@ -25,7 +25,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:54"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -49,7 +49,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:52"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -73,7 +73,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/lambda-extension-enabled.output.service.json
+++ b/tests/fixtures/lambda-extension-enabled.output.service.json
@@ -26,7 +26,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:54"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -50,7 +50,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:52"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -74,7 +74,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/license-key-secret-disabled.output.service.json
+++ b/tests/fixtures/license-key-secret-disabled.output.service.json
@@ -27,7 +27,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:54"
       ],
       "package": {
         "exclude": [
@@ -56,7 +56,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:52"
       ],
       "package": {
         "exclude": [
@@ -85,7 +85,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:22"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-disabled.output.service.json
+++ b/tests/fixtures/log-disabled.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:54"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -51,7 +51,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:52"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -71,7 +71,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/log-ingestion-via-extension.output.service.json
+++ b/tests/fixtures/log-ingestion-via-extension.output.service.json
@@ -30,7 +30,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:54"
       ],
       "package": {
         "exclude": [
@@ -60,7 +60,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:52"
       ],
       "package": {
         "exclude": [
@@ -90,7 +90,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:22"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-level.output.service.json
+++ b/tests/fixtures/log-level.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:54"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -54,7 +54,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:52"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -77,7 +77,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment-log-level.output.service.json
+++ b/tests/fixtures/provider-environment-log-level.output.service.json
@@ -34,7 +34,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:54"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -57,7 +57,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:52"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -80,7 +80,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment.output.service.json
+++ b/tests/fixtures/provider-environment.output.service.json
@@ -33,7 +33,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:54"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -56,7 +56,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:52"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -79,7 +79,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/proxy.output.service.json
+++ b/tests/fixtures/proxy.output.service.json
@@ -26,7 +26,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:54"
       ],
       "package": {
         "exclude": [
@@ -55,7 +55,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:52"
       ],
       "package": {
         "exclude": [
@@ -84,7 +84,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:22"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/stage-included.output.service.json
+++ b/tests/fixtures/stage-included.output.service.json
@@ -30,7 +30,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:53"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:54"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -50,7 +50,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:51"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:52"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -70,7 +70,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:21"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:22"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],


### PR DESCRIPTION
A user with ~90 functions was encountering sporadic bad gateway errors. Initially this seemed to be during the call to the layers API, but the result of that first call is cached, and that number of requests in a short time period should be well within the API's performance capabilities. It also has no rate limiting.


We did not have error logging around other http calls, though, particularly to NR servers and AWS. This adds some error logging for those cases.