### PR TITLE
docs: fix documentation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ custom:
 #### `stages` (optional)
 
 An array of stages that the plugin will be included for. If this key is not specified then all stages will be included.
+
+```yaml
+custom:
   stages:
       - prod
 ```


### PR DESCRIPTION
The example given for the `stages` option was incorrectly formatted and this caused a production bug for us because we used `include:` instead of `stages:`! 😄 