### PR TITLE
fix: Skip creating integration when MS or polling integrations exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [

--- a/src/api.ts
+++ b/src/api.ts
@@ -11,6 +11,8 @@ export const nerdgraphFetch = async (
   const gqlUrl =
     region === "eu"
       ? "https://api.eu.newrelic.com/graphql"
+      : region === "staging"
+      ? "https://staging-api.newrelic.com/graphql"
       : "https://api.newrelic.com/graphql";
 
   const agent =

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -66,7 +66,7 @@ export default class Integration {
         "No New Relic AWS Lambda integration found for this New Relic linked account and aws account."
       );
 
-      if (enableIntegration) {
+      if (enableIntegration && enableIntegration !== "false") {
         this.enable(externalId);
         return;
       }
@@ -251,6 +251,18 @@ export default class Integration {
     }
   }
 
+  private async requestRoleArn(RoleName: string) {
+    const params = {
+      RoleName
+    };
+
+    const {
+      Role: { Arn }
+    } = await this.awsProvider.request("IAM", "getRole", params);
+
+    return Arn;
+  }
+
   private async checkAwsIntegrationRole(externalId: string) {
     const { accountId } = this.config;
     if (!accountId) {
@@ -261,31 +273,29 @@ export default class Integration {
     }
 
     try {
-      const params = {
-        RoleName: `NewRelicLambdaIntegrationRole_${accountId}`
-      };
-
-      const {
-        Role: { Arn }
-      } = await this.awsProvider.request("IAM", "getRole", params);
-
-      return Arn;
+      return this.requestRoleArn(`NewRelicLambdaIntegrationRole_${accountId}`);
     } catch (err) {
-      this.serverless.cli.log(
-        "The required NewRelicLambdaIntegrationRole cannot be found; Creating Stack with NewRelicLambdaIntegrationRole."
-      );
-      const stackId = await this.createCFStack(accountId);
-      waitForStatus(
-        {
-          awsMethod: "describeStacks",
-          callbackMethod: () => this.enable(externalId),
-          methodParams: {
-            StackName: stackId
+      // We're limited to one rolename and a 64-character regex, so allowing for streams means a second query
+      try {
+        return this.requestRoleArn(`NewRelicInfrastructure-Integrations`);
+      } catch (fallbackErr) {
+        this.serverless.cli.log(
+          `Neither NewRelicLambdaIntegrationRole_${accountId} nor NewRelicInfrastructure-Integrations can be found.
+           Creating Stack with NewRelicLambdaIntegrationRole.`
+        );
+        const stackId = await this.createCFStack(accountId);
+        waitForStatus(
+          {
+            awsMethod: "describeStacks",
+            callbackMethod: () => this.enable(externalId),
+            methodParams: {
+              StackName: stackId
+            },
+            statusPath: "Stacks[0].StackStatus"
           },
-          statusPath: "Stacks[0].StackStatus"
-        },
-        this
-      );
+          this
+        );
+      }
     }
   }
 

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -30,9 +30,6 @@ export default class Integration {
       nrRegion,
       proxy
     } = this.config;
-    const {
-      linkedAccount = `New Relic Lambda Integration - ${accountId}`
-    } = this.config;
 
     const integrationData = await nerdgraphFetch(
       apiKey,
@@ -55,7 +52,6 @@ export default class Integration {
 
     const match = linkedAccounts.filter(account => {
       return (
-        account.name === linkedAccount &&
         account.externalId === externalId &&
         account.nrAccountId === parseInt(accountId, 10)
       );
@@ -255,10 +251,11 @@ export default class Integration {
     const params = {
       RoleName
     };
+    const response = await this.awsProvider.request("IAM", "getRole", params);
 
     const {
       Role: { Arn }
-    } = await this.awsProvider.request("IAM", "getRole", params);
+    } = response;
 
     return Arn;
   }
@@ -277,7 +274,9 @@ export default class Integration {
     } catch (err) {
       // We're limited to one rolename and a 64-character regex, so allowing for streams means a second query
       try {
-        return this.requestRoleArn(`NewRelicInfrastructure-Integrations`);
+        return this.requestRoleArn(
+          `NewRelicInfrastructure-Integrations|NewRelicStagingIntegration`
+        );
       } catch (fallbackErr) {
         this.serverless.cli.log(
           `Neither NewRelicLambdaIntegrationRole_${accountId} nor NewRelicInfrastructure-Integrations can be found.

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -274,9 +274,7 @@ export default class Integration {
     } catch (err) {
       // We're limited to one rolename and a 64-character regex, so allowing for streams means a second query
       try {
-        return this.requestRoleArn(
-          `NewRelicInfrastructure-Integrations|NewRelicStagingIntegration`
-        );
+        return this.requestRoleArn(`NewRelicInfrastructure-Integrations`);
       } catch (fallbackErr) {
         this.serverless.cli.log(
           `Neither NewRelicLambdaIntegrationRole_${accountId} nor NewRelicInfrastructure-Integrations can be found.


### PR DESCRIPTION
...or when `enableIntegration` is undefined or false.

Signed-off-by: mrickard <maurice@mauricerickard.com>