### PR TITLE
Remove old runtimes and noop if for unsupported architecture

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: cimg/node:10.16.2
+    - image: cimg/node:12.22.7
 
 jobs:
   install:

--- a/README.md
+++ b/README.md
@@ -333,10 +333,8 @@ custom:
 
 This plugin currently supports the following AWS runtimes:
 
-- nodejs10.x
 - nodejs12.x
 - nodejs14.x
-- python2.7
 - python3.6
 - python3.7
 - python3.8

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.2.0",
+      "name": "serverless-newrelic-lambda-layers",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fs-extra": "^9.1.0",
@@ -30,7 +31,7 @@
         "jest": "^27.3.1",
         "prettier": "^1.19.1",
         "ramda": "^0.27.1",
-        "serverless": "^2.66.1",
+        "serverless": "^2.68.0",
         "ts-jest": "^27.0.7",
         "tslint": "^5.20.1",
         "tslint-config-prettier": "^1.18.0",
@@ -1535,9 +1536,9 @@
       }
     },
     "node_modules/@serverless/components": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@serverless/components/-/components-3.18.0.tgz",
-      "integrity": "sha512-/mg+A9HACedGD3qJ0MxepmmBwFi3hwUYFNEDJi7Z63pkHvXg+jLEeHtbAx2HdqxY1SHH/LtRzZR4GBcFCaY+Og==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@serverless/components/-/components-3.18.1.tgz",
+      "integrity": "sha512-36XSYHjPkSEiSwWkl/xwWgYXa32Fk1CAbHvtWGheCtKV4+I3Yxzhe7FbgR84O0FeGQ/qM3QI8i5vtPUxeDeB9g==",
       "dev": true,
       "dependencies": {
         "@serverless/platform-client": "^4.2.2",
@@ -1633,9 +1634,9 @@
       }
     },
     "node_modules/@serverless/components/node_modules/ci-info": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
-      "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
+      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
       "dev": true
     },
     "node_modules/@serverless/components/node_modules/dotenv": {
@@ -2802,9 +2803,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1026.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1026.0.tgz",
-      "integrity": "sha512-MWLzZvsbS6NngiY1H9EcjFiH6UUiFFtE5k0TB6Sg5neCLVhzTzClwX6I0m9CgcFLDy4PrqMSlJBeVfk2OSWq3A==",
+      "version": "2.1043.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1043.0.tgz",
+      "integrity": "sha512-WysMTSLfi8ZCj6QAAitJkxObxOzGLhcu6FxoKHiEnrefvfQtSvwqUq7BbT/pIfijnF9dE/7e9XwjW8Dz/hqF4Q==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -3645,14 +3646,15 @@
       }
     },
     "node_modules/cli-progress-footer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cli-progress-footer/-/cli-progress-footer-2.1.1.tgz",
-      "integrity": "sha512-fBEAKLDp/CCMzQSeEbvz4POvomCekmT0LodI/mchzrjIPeLXQHJ9Gb28leAqEjdc9wyV40cjsB2aWpvO5MA7Pw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-progress-footer/-/cli-progress-footer-2.2.0.tgz",
+      "integrity": "sha512-bMlSuLbztsIefm04dOOYcyXOhB6ZhJi8CAqzXtTmwbZlei+BLWDOgzYApl16DJdKucmiOb/pmqmilO3YfobGDQ==",
       "dev": true,
       "dependencies": {
-        "cli-color": "^2.0.0",
+        "cli-color": "^2.0.1",
         "d": "^1.0.1",
         "es5-ext": "^0.10.53",
+        "mute-stream": "0.0.8",
         "process-utils": "^4.0.0",
         "timers-ext": "^0.1.7",
         "type": "^2.5.0"
@@ -3824,9 +3826,9 @@
       "dev": true
     },
     "node_modules/color-string": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
-      "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
+      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
       "dev": true,
       "dependencies": {
         "color-name": "^1.0.0",
@@ -5738,9 +5740,9 @@
       }
     },
     "node_modules/got": {
-      "version": "11.8.2",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
-      "integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
+      "version": "11.8.3",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.3.tgz",
+      "integrity": "sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==",
       "dev": true,
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
@@ -5748,7 +5750,7 @@
         "@types/cacheable-request": "^6.0.1",
         "@types/responselike": "^1.0.0",
         "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.1",
+        "cacheable-request": "^7.0.2",
         "decompress-response": "^6.0.0",
         "http2-wrapper": "^1.0.0-beta.5.2",
         "lowercase-keys": "^2.0.0",
@@ -8792,9 +8794,9 @@
       }
     },
     "node_modules/json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -8831,17 +8833,17 @@
       }
     },
     "node_modules/jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "engines": [
-        "node >=0.6.0"
-      ],
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/jszip": {
@@ -10525,9 +10527,9 @@
       }
     },
     "node_modules/protobufjs/node_modules/@types/node": {
-      "version": "16.11.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
-      "integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==",
+      "version": "16.11.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.11.tgz",
+      "integrity": "sha512-KB0sixD67CeecHC33MYn+eYARkqTheIRNuu97y2XMjR7Wu3XibO1vaY6VBV6O/a89SPI81cEUIYT87UqUWlZNw==",
       "dev": true
     },
     "node_modules/protobufjs/node_modules/long": {
@@ -11085,28 +11087,28 @@
       }
     },
     "node_modules/serverless": {
-      "version": "2.66.1",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-2.66.1.tgz",
-      "integrity": "sha512-Swf5aHivSfU0fKuvV4FY0WmMNBZVx7cVK3FcxWLX1lFuzUQ+5D/bpunHW4lmg4tKmGtjBnQ0oQ+4N2MHE3wPrg==",
+      "version": "2.68.0",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-2.68.0.tgz",
+      "integrity": "sha512-RFhbwobdTEy/GsisYgLijjamKMpQpPdqD7rKXIFB8Ahfllnk+yFbP0fp/UdOH9qGATik8SISO+0wn5zjrhahxg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@serverless/cli": "^1.5.3",
-        "@serverless/components": "^3.18.0",
+        "@serverless/components": "^3.18.1",
         "@serverless/dashboard-plugin": "^5.5.1",
         "@serverless/platform-client": "^4.3.0",
         "@serverless/utils": "^5.20.1",
         "ajv": "^6.12.6",
         "ajv-keywords": "^3.5.2",
         "archiver": "^5.3.0",
-        "aws-sdk": "^2.1025.0",
+        "aws-sdk": "^2.1041.0",
         "bluebird": "^3.7.2",
         "boxen": "^5.1.2",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.2",
         "child-process-ext": "^2.1.1",
-        "ci-info": "^3.2.0",
-        "cli-progress-footer": "^2.1.1",
+        "ci-info": "^3.3.0",
+        "cli-progress-footer": "^2.2.0",
         "d": "^1.0.1",
         "dayjs": "^1.10.7",
         "decompress": "^4.2.1",
@@ -11119,7 +11121,7 @@
         "fs-extra": "^9.1.0",
         "get-stdin": "^8.0.0",
         "globby": "^11.0.4",
-        "got": "^11.8.2",
+        "got": "^11.8.3",
         "graceful-fs": "^4.2.8",
         "https-proxy-agent": "^5.0.0",
         "is-docker": "^2.2.1",
@@ -11138,7 +11140,7 @@
         "promise-queue": "^2.2.5",
         "replaceall": "^0.1.6",
         "semver": "^7.3.5",
-        "signal-exit": "^3.0.5",
+        "signal-exit": "^3.0.6",
         "strip-ansi": "^6.0.1",
         "tabtab": "^3.0.2",
         "tar": "^6.1.11",
@@ -11205,49 +11207,10 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/serverless/node_modules/chalk/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/serverless/node_modules/chalk/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/serverless/node_modules/chalk/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/serverless/node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/serverless/node_modules/ci-info": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
-      "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
+      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
       "dev": true
     },
     "node_modules/serverless/node_modules/js-yaml": {
@@ -11333,9 +11296,9 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
-      "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
+      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
       "dev": true
     },
     "node_modules/simple-concat": {
@@ -14607,9 +14570,9 @@
       }
     },
     "@serverless/components": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@serverless/components/-/components-3.18.0.tgz",
-      "integrity": "sha512-/mg+A9HACedGD3qJ0MxepmmBwFi3hwUYFNEDJi7Z63pkHvXg+jLEeHtbAx2HdqxY1SHH/LtRzZR4GBcFCaY+Og==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@serverless/components/-/components-3.18.1.tgz",
+      "integrity": "sha512-36XSYHjPkSEiSwWkl/xwWgYXa32Fk1CAbHvtWGheCtKV4+I3Yxzhe7FbgR84O0FeGQ/qM3QI8i5vtPUxeDeB9g==",
       "dev": true,
       "requires": {
         "@serverless/platform-client": "^4.2.2",
@@ -14689,9 +14652,9 @@
           }
         },
         "ci-info": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
-          "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
+          "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
           "dev": true
         },
         "dotenv": {
@@ -15727,9 +15690,9 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "aws-sdk": {
-      "version": "2.1026.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1026.0.tgz",
-      "integrity": "sha512-MWLzZvsbS6NngiY1H9EcjFiH6UUiFFtE5k0TB6Sg5neCLVhzTzClwX6I0m9CgcFLDy4PrqMSlJBeVfk2OSWq3A==",
+      "version": "2.1043.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1043.0.tgz",
+      "integrity": "sha512-WysMTSLfi8ZCj6QAAitJkxObxOzGLhcu6FxoKHiEnrefvfQtSvwqUq7BbT/pIfijnF9dE/7e9XwjW8Dz/hqF4Q==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -16392,14 +16355,15 @@
       }
     },
     "cli-progress-footer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cli-progress-footer/-/cli-progress-footer-2.1.1.tgz",
-      "integrity": "sha512-fBEAKLDp/CCMzQSeEbvz4POvomCekmT0LodI/mchzrjIPeLXQHJ9Gb28leAqEjdc9wyV40cjsB2aWpvO5MA7Pw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-progress-footer/-/cli-progress-footer-2.2.0.tgz",
+      "integrity": "sha512-bMlSuLbztsIefm04dOOYcyXOhB6ZhJi8CAqzXtTmwbZlei+BLWDOgzYApl16DJdKucmiOb/pmqmilO3YfobGDQ==",
       "dev": true,
       "requires": {
-        "cli-color": "^2.0.0",
+        "cli-color": "^2.0.1",
         "d": "^1.0.1",
         "es5-ext": "^0.10.53",
+        "mute-stream": "0.0.8",
         "process-utils": "^4.0.0",
         "timers-ext": "^0.1.7",
         "type": "^2.5.0"
@@ -16556,9 +16520,9 @@
       "dev": true
     },
     "color-string": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
-      "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
+      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
       "dev": true,
       "requires": {
         "color-name": "^1.0.0",
@@ -18091,9 +18055,9 @@
       }
     },
     "got": {
-      "version": "11.8.2",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
-      "integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
+      "version": "11.8.3",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.3.tgz",
+      "integrity": "sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==",
       "dev": true,
       "requires": {
         "@sindresorhus/is": "^4.0.0",
@@ -18101,7 +18065,7 @@
         "@types/cacheable-request": "^6.0.1",
         "@types/responselike": "^1.0.0",
         "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.1",
+        "cacheable-request": "^7.0.2",
         "decompress-response": "^6.0.0",
         "http2-wrapper": "^1.0.0-beta.5.2",
         "lowercase-keys": "^2.0.0",
@@ -20539,9 +20503,9 @@
       }
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -20572,13 +20536,13 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },
@@ -21940,9 +21904,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "16.11.7",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
-          "integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==",
+          "version": "16.11.11",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.11.tgz",
+          "integrity": "sha512-KB0sixD67CeecHC33MYn+eYARkqTheIRNuu97y2XMjR7Wu3XibO1vaY6VBV6O/a89SPI81cEUIYT87UqUWlZNw==",
           "dev": true
         },
         "long": {
@@ -22348,27 +22312,27 @@
       "dev": true
     },
     "serverless": {
-      "version": "2.66.1",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-2.66.1.tgz",
-      "integrity": "sha512-Swf5aHivSfU0fKuvV4FY0WmMNBZVx7cVK3FcxWLX1lFuzUQ+5D/bpunHW4lmg4tKmGtjBnQ0oQ+4N2MHE3wPrg==",
+      "version": "2.68.0",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-2.68.0.tgz",
+      "integrity": "sha512-RFhbwobdTEy/GsisYgLijjamKMpQpPdqD7rKXIFB8Ahfllnk+yFbP0fp/UdOH9qGATik8SISO+0wn5zjrhahxg==",
       "dev": true,
       "requires": {
         "@serverless/cli": "^1.5.3",
-        "@serverless/components": "^3.18.0",
+        "@serverless/components": "^3.18.1",
         "@serverless/dashboard-plugin": "^5.5.1",
         "@serverless/platform-client": "^4.3.0",
         "@serverless/utils": "^5.20.1",
         "ajv": "^6.12.6",
         "ajv-keywords": "^3.5.2",
         "archiver": "^5.3.0",
-        "aws-sdk": "^2.1025.0",
+        "aws-sdk": "^2.1041.0",
         "bluebird": "^3.7.2",
         "boxen": "^5.1.2",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.2",
         "child-process-ext": "^2.1.1",
-        "ci-info": "^3.2.0",
-        "cli-progress-footer": "^2.1.1",
+        "ci-info": "^3.3.0",
+        "cli-progress-footer": "^2.2.0",
         "d": "^1.0.1",
         "dayjs": "^1.10.7",
         "decompress": "^4.2.1",
@@ -22381,7 +22345,7 @@
         "fs-extra": "^9.1.0",
         "get-stdin": "^8.0.0",
         "globby": "^11.0.4",
-        "got": "^11.8.2",
+        "got": "^11.8.3",
         "graceful-fs": "^4.2.8",
         "https-proxy-agent": "^5.0.0",
         "is-docker": "^2.2.1",
@@ -22400,7 +22364,7 @@
         "promise-queue": "^2.2.5",
         "replaceall": "^0.1.6",
         "semver": "^7.3.5",
-        "signal-exit": "^3.0.5",
+        "signal-exit": "^3.0.6",
         "strip-ansi": "^6.0.1",
         "tabtab": "^3.0.2",
         "tar": "^6.1.11",
@@ -22447,43 +22411,13 @@
               "requires": {
                 "color-convert": "^2.0.1"
               }
-            },
-            "color-convert": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-              "dev": true,
-              "requires": {
-                "color-name": "~1.1.4"
-              }
-            },
-            "color-name": {
-              "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-              "dev": true
-            },
-            "has-flag": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-              "dev": true
-            },
-            "supports-color": {
-              "version": "7.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
             }
           }
         },
         "ci-info": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
-          "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
+          "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
           "dev": true
         },
         "js-yaml": {
@@ -22550,9 +22484,9 @@
       }
     },
     "signal-exit": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
-      "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
+      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
       "dev": true
     },
     "simple-concat": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "2.2.1",
+  "version": "3.0.0",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [
@@ -44,7 +44,7 @@
     "jest": "^27.3.1",
     "prettier": "^1.19.1",
     "ramda": "^0.27.1",
-    "serverless": "^2.66.1",
+    "serverless": "^2.68.0",
     "ts-jest": "^27.0.7",
     "tslint": "^5.20.1",
     "tslint-config-prettier": "^1.18.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -382,10 +382,8 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
 
     const wrappableRuntime =
       [
-        "nodejs10.x",
         "nodejs12.x",
         "nodejs14.x",
-        "python2.7",
         "python3.6",
         "python3.7",
         "python3.8",

--- a/src/index.ts
+++ b/src/index.ts
@@ -410,6 +410,10 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
       ? this.config.layerArn
       : await this.getLayerArn(runtime, architecture);
 
+    if (!layerArn) {
+      return;
+    }
+
     const newRelicLayers = layers.filter(
       layer => typeof layer === "string" && layer.match(layerArn)
     );
@@ -542,17 +546,44 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
   }
 
   private async getLayerArn(runtime: string, architecture?: string) {
-    let url = `https://${this.region}.layers.newrelic-external.com/get-layers?CompatibleRuntime=${runtime}`;
-    if (architecture) {
-      url = `${url}&CompatibleArchitecture=${architecture}`;
-    }
+    const url = `https://${this.region}.layers.newrelic-external.com/get-layers?CompatibleRuntime=${runtime}`;
     return request(url)
       .then(response => {
         const awsResp = JSON.parse(response);
-        return _.get(
-          awsResp,
-          "Layers[0].LatestMatchingVersion.LayerVersionArn"
-        );
+        const layers = _.get(awsResp, "Layers", []);
+        const compatibleLayers = layers
+          .map(layer => {
+            const latestLayer = layer.LatestMatchingVersion;
+            const latestArch = latestLayer.CompatibleArchitectures;
+            const latestArchHasValues =
+              latestArch && latestArch.length && latestArch.length > 0;
+
+            if (
+              !architecture &&
+              (!latestArch ||
+                (latestArchHasValues && latestArch[0] === "x86_64"))
+            ) {
+              return latestLayer;
+            } else if (
+              architecture &&
+              latestArchHasValues &&
+              architecture === latestArch[0]
+            ) {
+              return latestLayer;
+            }
+          })
+          .filter(layer => typeof layer !== "undefined");
+
+        if (
+          !compatibleLayers ||
+          (compatibleLayers.length < 1 && architecture)
+        ) {
+          this.serverless.cli.log(
+            `${architecture} is not yet supported by New Relic layers for ${runtime} in ${this.region}. Skipping.`
+          );
+          return false;
+        }
+        return compatibleLayers[0].LayerVersionArn;
       })
       .catch(reason => {
         this.serverless.cli.log(
@@ -560,6 +591,7 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
         );
         this.serverless.cli.log(`URL: ${url}`);
         this.serverless.cli.log(reason);
+        return;
       });
   }
 

--- a/tests/fixtures/arm64-unsupported.output.service.json
+++ b/tests/fixtures/arm64-unsupported.output.service.json
@@ -11,27 +11,15 @@
   "disabledDeprecations": [],
   "functions": {
     "layer-nodejs12x": {
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      },
       "events": [
         {
           "schedule": "rate(5 minutes)"
         }
       ],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:ap-northeast-2:451483290750:layer:NewRelicNodeJS12X:58"
-      ],
+      "handler": "handler.handler",
       "package": {
         "exclude": [
-          "./**",
-          "!newrelic-wrapper-helper.js"
+          "./**"
         ],
         "include": [
           "handler.js"
@@ -40,27 +28,15 @@
       "runtime": "nodejs12.x"
     },
     "layer-nodejs14x": {
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs14x",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      },
       "events": [
         {
           "schedule": "rate(5 minutes)"
         }
       ],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:ap-northeast-2:451483290750:layer:NewRelicNodeJS14X:28"
-      ],
+      "handler": "handler.handler",
       "package": {
         "exclude": [
-          "./**",
-          "!newrelic-wrapper-helper.js"
+          "./**"
         ],
         "include": [
           "handler.js"

--- a/tests/fixtures/arm64.output.service.json
+++ b/tests/fixtures/arm64.output.service.json
@@ -26,7 +26,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12XARM64:3"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12XARM64:8"
       ],
       "package": {
         "exclude": [
@@ -55,7 +55,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14XARM64:2"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14XARM64:7"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/debug-log-level.input.service.json
+++ b/tests/fixtures/debug-log-level.input.service.json
@@ -27,12 +27,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/debug-log-level.output.service.json
+++ b/tests/fixtures/debug-log-level.output.service.json
@@ -28,34 +28,11 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:55"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs10.x",
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs10x",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_LOG": "stdout",
-        "NEW_RELIC_LOG_LEVEL": "error",
-        "NEW_RELIC_LOG_ENABLED": "true",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:63"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -78,7 +55,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:28"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/debug.input.service.json
+++ b/tests/fixtures/debug.input.service.json
@@ -26,12 +26,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/debug.output.service.json
+++ b/tests/fixtures/debug.output.service.json
@@ -27,34 +27,11 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:55"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs10.x",
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs10x",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_LOG": "stdout",
-        "NEW_RELIC_LOG_LEVEL": "debug",
-        "NEW_RELIC_LOG_ENABLED": "true",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:63"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -77,7 +54,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:28"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/distributed-tracing-enabled.input.service.json
+++ b/tests/fixtures/distributed-tracing-enabled.input.service.json
@@ -25,17 +25,17 @@
     }
   },
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
       "runtime": "nodejs12.x"
+    },
+    "layer-nodejs14x": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs14.x"
     }
   }
 }

--- a/tests/fixtures/distributed-tracing-enabled.output.service.json
+++ b/tests/fixtures/distributed-tracing-enabled.output.service.json
@@ -11,31 +11,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs10x",
-        "NEW_RELIC_DISTRIBUTED_TRACING_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      },
-      "events": [
-        {
-          "schedule": "rate(5 minutes)"
-        }
-      ],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:55"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
@@ -53,14 +28,44 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:63"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
       "runtime": "nodejs12.x"
-    }
+    },
+    "layer-nodejs14x": {
+         "environment": {
+         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
+         "NEW_RELIC_APP_NAME": "layer-nodejs14x",
+         "NEW_RELIC_DISTRIBUTED_TRACING_ENABLED": "true",
+         "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
+         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
+         "NEW_RELIC_NO_CONFIG_FILE": "true",
+         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
+       },
+       "events": [
+         {
+           "schedule": "rate(5 minutes)"
+         }
+       ],
+       "handler": "newrelic-lambda-wrapper.handler",
+       "layers": [
+         "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:33"
+       ],
+       "package": {
+         "exclude": [
+           "./**",
+           "!newrelic-wrapper-helper.js"
+         ],
+         "include": [
+           "handler.js"
+         ]
+       },
+       "runtime": "nodejs14.x"
+     }
   },
   "plugins": ["serverless-newrelic-lambda-layers"],
   "provider": {

--- a/tests/fixtures/eu.input.service.json
+++ b/tests/fixtures/eu.input.service.json
@@ -27,12 +27,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/eu.output.service.json
+++ b/tests/fixtures/eu.output.service.json
@@ -11,33 +11,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs10x",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_LOG": "stdout",
-        "NEW_RELIC_LOG_ENABLED": "true",
-        "NEW_RELIC_LOG_LEVEL": "debug",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      },
-      "events": [
-        {
-          "schedule": "rate(5 minutes)"
-        }
-      ],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:55"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
@@ -57,7 +30,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:63"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -84,7 +57,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:28"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/include-exclude.input.service.json
+++ b/tests/fixtures/include-exclude.input.service.json
@@ -21,18 +21,12 @@
     "newRelic": {
       "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
       "enableExtension": true,
-      "include": ["layer-nodejs10x"],
-      "exclude": ["layer-nodejs12x"]
+      "include": ["layer-nodejs12x"],
+      "exclude": ["layer-nodejs14x"]
     }
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/include-exclude.output.service.json
+++ b/tests/fixtures/include-exclude.output.service.json
@@ -21,18 +21,12 @@
     "newRelic": {
       "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
       "enableExtension": true,
-      "include": ["layer-nodejs10x"],
-      "exclude": ["layer-nodejs12x"]
+      "include": ["layer-nodejs12x"],
+      "exclude": ["layer-nodejs14x"]
     }
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/include.input.service.json
+++ b/tests/fixtures/include.input.service.json
@@ -20,17 +20,11 @@
   "custom": {
     "newRelic": {
       "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
-      "include": ["layer-nodejs10x"]
+      "include": ["layer-nodejs12x"]
     }
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/include.output.service.json
+++ b/tests/fixtures/include.output.service.json
@@ -21,33 +21,26 @@
     "newRelic": {
       "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
       "enableExtension": true,
-      "include": ["layer-nodejs10x"]
+      "include": ["layer-nodejs12x"]
     }
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
+    "layer-nodejs12x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs10x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs12x",
         "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-       },
-
+      },
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:55"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:63"
       ],
       "package": { "exclude": ["./**", "!newrelic-wrapper-helper.js"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
-    "layer-nodejs12x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
       "runtime": "nodejs12.x"
     },
     "layer-nodejs14x": {

--- a/tests/fixtures/lambda-extension-disabled.input.service.json
+++ b/tests/fixtures/lambda-extension-disabled.input.service.json
@@ -24,12 +24,6 @@
     }
   },
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/lambda-extension-disabled.output.service.json
+++ b/tests/fixtures/lambda-extension-disabled.output.service.json
@@ -9,30 +9,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs10x",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "false",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      },
-      "events": [
-        {
-          "schedule": "rate(5 minutes)"
-        }
-      ],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:55"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
@@ -49,7 +25,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:63"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -73,7 +49,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:28"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/lambda-extension-enabled.input.service.json
+++ b/tests/fixtures/lambda-extension-enabled.input.service.json
@@ -24,12 +24,6 @@
     }
   },
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/lambda-extension-enabled.output.service.json
+++ b/tests/fixtures/lambda-extension-enabled.output.service.json
@@ -10,30 +10,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs10x",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      },
-      "events": [
-        {
-          "schedule": "rate(5 minutes)"
-        }
-      ],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:55"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
@@ -50,7 +26,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:63"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -74,7 +50,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:28"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/license-key-secret-disabled.input.service.json
+++ b/tests/fixtures/license-key-secret-disabled.input.service.json
@@ -25,12 +25,6 @@
     }
   },
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/license-key-secret-disabled.output.service.json
+++ b/tests/fixtures/license-key-secret-disabled.output.service.json
@@ -11,35 +11,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs10x",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      },
-      "events": [
-        {
-          "schedule": "rate(5 minutes)"
-        }
-      ],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:55"
-      ],
-      "package": {
-        "exclude": [
-          "./**",
-          "!newrelic-wrapper-helper.js"
-        ],
-        "include": [
-          "handler.js"
-        ]
-      },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
@@ -56,7 +27,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:63"
       ],
       "package": {
         "exclude": [
@@ -85,7 +56,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:28"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:33"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-disabled.input.service.json
+++ b/tests/fixtures/log-disabled.input.service.json
@@ -26,12 +26,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/log-disabled.output.service.json
+++ b/tests/fixtures/log-disabled.output.service.json
@@ -27,31 +27,11 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:55"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs10.x",
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs10x",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:63"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -71,7 +51,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:28"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/log-ingestion-via-extension.input.service.json
+++ b/tests/fixtures/log-ingestion-via-extension.input.service.json
@@ -27,12 +27,6 @@
     }
   },
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/log-ingestion-via-extension.output.service.json
+++ b/tests/fixtures/log-ingestion-via-extension.output.service.json
@@ -13,36 +13,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs10x",
-        "NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS": "true",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      },
-      "events": [
-        {
-          "schedule": "rate(5 minutes)"
-        }
-      ],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:55"
-      ],
-      "package": {
-        "exclude": [
-          "./**",
-          "!newrelic-wrapper-helper.js"
-        ],
-        "include": [
-          "handler.js"
-        ]
-      },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
@@ -60,7 +30,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:63"
       ],
       "package": {
         "exclude": [
@@ -90,7 +60,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:28"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:33"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-level.input.service.json
+++ b/tests/fixtures/log-level.input.service.json
@@ -26,12 +26,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/log-level.output.service.json
+++ b/tests/fixtures/log-level.output.service.json
@@ -27,34 +27,11 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:55"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs10.x",
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs10x",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_LOG": "stdout",
-        "NEW_RELIC_LOG_LEVEL": "error",
-        "NEW_RELIC_LOG_ENABLED": "true",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:63"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -77,7 +54,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:28"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment-log-level.input.service.json
+++ b/tests/fixtures/provider-environment-log-level.input.service.json
@@ -29,12 +29,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/provider-environment-log-level.output.service.json
+++ b/tests/fixtures/provider-environment-log-level.output.service.json
@@ -30,34 +30,11 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:55"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs10.x",
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs10x",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_LOG": "stdout",
-        "NEW_RELIC_LOG_LEVEL": "error",
-        "NEW_RELIC_LOG_ENABLED": "true",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:63"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -80,7 +57,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:28"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment.input.service.json
+++ b/tests/fixtures/provider-environment.input.service.json
@@ -28,12 +28,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/provider-environment.output.service.json
+++ b/tests/fixtures/provider-environment.output.service.json
@@ -29,34 +29,11 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:55"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs10.x",
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs10x",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_LOG": "stdout",
-        "NEW_RELIC_LOG_LEVEL": "error",
-        "NEW_RELIC_LOG_ENABLED": "true",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:63"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -79,7 +56,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:28"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/proxy.input.service.json
+++ b/tests/fixtures/proxy.input.service.json
@@ -25,12 +25,6 @@
     }
   },
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/proxy.output.service.json
+++ b/tests/fixtures/proxy.output.service.json
@@ -10,35 +10,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs10x",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      },
-      "events": [
-        {
-          "schedule": "rate(5 minutes)"
-        }
-      ],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:55"
-      ],
-      "package": {
-        "exclude": [
-          "./**",
-          "!newrelic-wrapper-helper.js"
-        ],
-        "include": [
-          "handler.js"
-        ]
-      },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
@@ -55,7 +26,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:63"
       ],
       "package": {
         "exclude": [
@@ -84,7 +55,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:28"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:33"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/stage-excluded.input.service.json
+++ b/tests/fixtures/stage-excluded.input.service.json
@@ -25,12 +25,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/stage-excluded.output.service.json
+++ b/tests/fixtures/stage-excluded.output.service.json
@@ -25,12 +25,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/stage-included.input.service.json
+++ b/tests/fixtures/stage-included.input.service.json
@@ -25,12 +25,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/stage-included.output.service.json
+++ b/tests/fixtures/stage-included.output.service.json
@@ -26,31 +26,11 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:55"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs10.x",
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs10x",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:63"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -70,7 +50,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:28"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/trusted-account-key-excluded.input.service.json
+++ b/tests/fixtures/trusted-account-key-excluded.input.service.json
@@ -24,12 +24,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/trusted-account-key-excluded.output.service.json
+++ b/tests/fixtures/trusted-account-key-excluded.output.service.json
@@ -25,31 +25,11 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:55"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs10.x",
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs10x",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:63"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -69,7 +49,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:28"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/trusted-account-key-included.input.service.json
+++ b/tests/fixtures/trusted-account-key-included.input.service.json
@@ -25,12 +25,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs10.x"
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/trusted-account-key-included.output.service.json
+++ b/tests/fixtures/trusted-account-key-included.output.service.json
@@ -26,31 +26,11 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs10x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS10X:55"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs10.x",
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs10x",
-        "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "true",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_TRUSTED_ACCOUNT_KEY}"
-      }
-    },
     "layer-nodejs12x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:63"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -70,7 +50,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:28"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],


### PR DESCRIPTION
Removing Node 10 and Python 2.7 from plugin and tests

Plugin does not continue with instrumentation if we don't have a layer for the requested architecture. 

Updates to serverless dependency.