### PR TITLE
fix: Updating build container to Node 12, Node 10 having been EOL'd.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: cimg/node:10.16.2
+    - image: cimg/node:12.22.7
 
 jobs:
   install:


### PR DESCRIPTION
Can be directed at `master` once LAMBDA-1356 is closed, or merged into 1356.

Signed-off-by: mrickard <maurice@mauricerickard.com>