### PR TITLE
Updating serverless to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "jest": "^27.3.1",
         "prettier": "^1.19.1",
         "ramda": "^0.27.1",
-        "serverless": "^2.70.0",
+        "serverless": "^2.71.0",
         "ts-jest": "^27.0.7",
         "tslint": "^5.20.1",
         "tslint-config-prettier": "^1.18.0",
@@ -1403,9 +1403,9 @@
       "dev": true
     },
     "node_modules/@serverless/cli": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@serverless/cli/-/cli-1.5.3.tgz",
-      "integrity": "sha512-ZJ0Y7CsYoE/i45XkIMl/XBZO4KIlt0XH1qwxxNE2/84bZlih5cgRV6MZ+rKt7GlrD0iDAgQGyGv5dpyt+SGhKw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@serverless/cli/-/cli-1.6.0.tgz",
+      "integrity": "sha512-1Muw/KhS4sZ6+ZrXBdmVY9zAwZh03lF7v1DKtaZ0cmxjqQBwPLoO40rOGXlxR97pyufe2NS6rD/p+ri8NGqeXg==",
       "dev": true,
       "dependencies": {
         "@serverless/core": "^1.1.2",
@@ -1421,7 +1421,8 @@
         "strip-ansi": "^6.0.1"
       },
       "bin": {
-        "components": "bin/bin"
+        "components": "bin/bin",
+        "components-v1": "bin/bin"
       }
     },
     "node_modules/@serverless/cli/node_modules/@serverless/utils": {
@@ -1765,9 +1766,9 @@
       }
     },
     "node_modules/@serverless/dashboard-plugin": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@serverless/dashboard-plugin/-/dashboard-plugin-5.5.2.tgz",
-      "integrity": "sha512-w//z0A5IJ52kwbHken4QEx+vo/T2WHbmHFR5CblVbe2LpswgSJ2IEUHrbm/Tp9V/1QtGrVVXRVxgOPxoAChFwg==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/@serverless/dashboard-plugin/-/dashboard-plugin-5.5.3.tgz",
+      "integrity": "sha512-CmmtuEvkMrj0jBqB3BF6GffZ+izH1AI0JiCaANrUrfUmmBBcanxUqYd6QqUp49yMSIrUH/j3U6SzODkDLjB0fA==",
       "dev": true,
       "dependencies": {
         "@serverless/event-mocks": "^1.1.1",
@@ -2815,9 +2816,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1049.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1049.0.tgz",
-      "integrity": "sha512-+wls9iNlotMeoZepwgR0yPzXsjXzr2ijoi5ERmsPWfMTFMHkm6INndBtSkm6fpu/NZnl+7EaPPES2yhaqnhoJg==",
+      "version": "2.1053.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1053.0.tgz",
+      "integrity": "sha512-bsVudymGczfn7kOsY9tiMFZUCNFOQi7iG3d1HiBFrnEDCKtVTyKuFrXy4iKUPCcjfOaqNnb1S3ZxN/A70MOTkg==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -4141,9 +4142,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -5217,9 +5218,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.10.tgz",
+      "integrity": "sha512-s9nFhFnvR63wls6/kM88kQqDhMu0AfdjqouE2l5GVQPbqLgyFjjU5ry/r2yKsJxpb9Py1EYNqieFrmMaX4v++A==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -5229,7 +5230,7 @@
         "micromatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=8.6.0"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -5766,16 +5767,16 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -5811,9 +5812,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
     "node_modules/graphlib": {
       "version": "2.1.8",
@@ -6133,9 +6134,9 @@
       "dev": true
     },
     "node_modules/ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -11177,21 +11178,21 @@
       }
     },
     "node_modules/serverless": {
-      "version": "2.70.0",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-2.70.0.tgz",
-      "integrity": "sha512-NoaaylJFgDhbEWLashrerle8jx35b6iGdF3s+gYOzj8wvLhMOF3rfWzeKNyCBVXC0syx1Q5aYgaYVHUMzXzmSw==",
+      "version": "2.71.0",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-2.71.0.tgz",
+      "integrity": "sha512-2iKZqeEi0AcYo+jPxMRCGmWNZ56An+S0rrW8s9rmdSP8typ8cwGMWHQSwPxMVAP/UWASh9E8d8q6Uzoq8sJcnA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@serverless/cli": "^1.5.3",
+        "@serverless/cli": "^1.6.0",
         "@serverless/components": "^3.18.1",
-        "@serverless/dashboard-plugin": "^5.5.2",
+        "@serverless/dashboard-plugin": "^5.5.3",
         "@serverless/platform-client": "^4.3.0",
         "@serverless/utils": "^5.20.2",
         "ajv": "^6.12.6",
         "ajv-keywords": "^3.5.2",
         "archiver": "^5.3.0",
-        "aws-sdk": "^2.1048.0",
+        "aws-sdk": "^2.1053.0",
         "bluebird": "^3.7.2",
         "boxen": "^5.1.2",
         "cachedir": "^2.3.0",
@@ -11210,9 +11211,9 @@
         "filesize": "^8.0.6",
         "fs-extra": "^9.1.0",
         "get-stdin": "^8.0.0",
-        "globby": "^11.0.4",
+        "globby": "^11.1.0",
         "got": "^11.8.3",
-        "graceful-fs": "^4.2.8",
+        "graceful-fs": "^4.2.9",
         "https-proxy-agent": "^5.0.0",
         "is-docker": "^2.2.1",
         "is-wsl": "^2.2.0",
@@ -11225,6 +11226,7 @@
         "ncjsm": "^4.2.0",
         "node-fetch": "^2.6.6",
         "object-hash": "^2.2.0",
+        "open": "^7.4.2",
         "path2": "^0.1.0",
         "process-utils": "^4.0.0",
         "promise-queue": "^2.2.5",
@@ -11454,23 +11456,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/steveukx/"
-      }
-    },
-    "node_modules/simple-git/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/simple-swizzle": {
@@ -14560,9 +14545,9 @@
       "dev": true
     },
     "@serverless/cli": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@serverless/cli/-/cli-1.5.3.tgz",
-      "integrity": "sha512-ZJ0Y7CsYoE/i45XkIMl/XBZO4KIlt0XH1qwxxNE2/84bZlih5cgRV6MZ+rKt7GlrD0iDAgQGyGv5dpyt+SGhKw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@serverless/cli/-/cli-1.6.0.tgz",
+      "integrity": "sha512-1Muw/KhS4sZ6+ZrXBdmVY9zAwZh03lF7v1DKtaZ0cmxjqQBwPLoO40rOGXlxR97pyufe2NS6rD/p+ri8NGqeXg==",
       "dev": true,
       "requires": {
         "@serverless/core": "^1.1.2",
@@ -14867,9 +14852,9 @@
       }
     },
     "@serverless/dashboard-plugin": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@serverless/dashboard-plugin/-/dashboard-plugin-5.5.2.tgz",
-      "integrity": "sha512-w//z0A5IJ52kwbHken4QEx+vo/T2WHbmHFR5CblVbe2LpswgSJ2IEUHrbm/Tp9V/1QtGrVVXRVxgOPxoAChFwg==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/@serverless/dashboard-plugin/-/dashboard-plugin-5.5.3.tgz",
+      "integrity": "sha512-CmmtuEvkMrj0jBqB3BF6GffZ+izH1AI0JiCaANrUrfUmmBBcanxUqYd6QqUp49yMSIrUH/j3U6SzODkDLjB0fA==",
       "dev": true,
       "requires": {
         "@serverless/event-mocks": "^1.1.1",
@@ -15797,9 +15782,9 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "aws-sdk": {
-      "version": "2.1049.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1049.0.tgz",
-      "integrity": "sha512-+wls9iNlotMeoZepwgR0yPzXsjXzr2ijoi5ERmsPWfMTFMHkm6INndBtSkm6fpu/NZnl+7EaPPES2yhaqnhoJg==",
+      "version": "2.1053.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1053.0.tgz",
+      "integrity": "sha512-bsVudymGczfn7kOsY9tiMFZUCNFOQi7iG3d1HiBFrnEDCKtVTyKuFrXy4iKUPCcjfOaqNnb1S3ZxN/A70MOTkg==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -16867,9 +16852,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -17742,9 +17727,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.10.tgz",
+      "integrity": "sha512-s9nFhFnvR63wls6/kM88kQqDhMu0AfdjqouE2l5GVQPbqLgyFjjU5ry/r2yKsJxpb9Py1EYNqieFrmMaX4v++A==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -18155,16 +18140,16 @@
       "dev": true
     },
     "globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       }
     },
@@ -18188,9 +18173,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
     "graphlib": {
       "version": "2.1.8",
@@ -18431,9 +18416,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
     "immediate": {
@@ -22450,20 +22435,20 @@
       "dev": true
     },
     "serverless": {
-      "version": "2.70.0",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-2.70.0.tgz",
-      "integrity": "sha512-NoaaylJFgDhbEWLashrerle8jx35b6iGdF3s+gYOzj8wvLhMOF3rfWzeKNyCBVXC0syx1Q5aYgaYVHUMzXzmSw==",
+      "version": "2.71.0",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-2.71.0.tgz",
+      "integrity": "sha512-2iKZqeEi0AcYo+jPxMRCGmWNZ56An+S0rrW8s9rmdSP8typ8cwGMWHQSwPxMVAP/UWASh9E8d8q6Uzoq8sJcnA==",
       "dev": true,
       "requires": {
-        "@serverless/cli": "^1.5.3",
+        "@serverless/cli": "^1.6.0",
         "@serverless/components": "^3.18.1",
-        "@serverless/dashboard-plugin": "^5.5.2",
+        "@serverless/dashboard-plugin": "^5.5.3",
         "@serverless/platform-client": "^4.3.0",
         "@serverless/utils": "^5.20.2",
         "ajv": "^6.12.6",
         "ajv-keywords": "^3.5.2",
         "archiver": "^5.3.0",
-        "aws-sdk": "^2.1048.0",
+        "aws-sdk": "^2.1053.0",
         "bluebird": "^3.7.2",
         "boxen": "^5.1.2",
         "cachedir": "^2.3.0",
@@ -22482,9 +22467,9 @@
         "filesize": "^8.0.6",
         "fs-extra": "^9.1.0",
         "get-stdin": "^8.0.0",
-        "globby": "^11.0.4",
+        "globby": "^11.1.0",
         "got": "^11.8.3",
-        "graceful-fs": "^4.2.8",
+        "graceful-fs": "^4.2.9",
         "https-proxy-agent": "^5.0.0",
         "is-docker": "^2.2.1",
         "is-wsl": "^2.2.0",
@@ -22497,6 +22482,7 @@
         "ncjsm": "^4.2.0",
         "node-fetch": "^2.6.6",
         "object-hash": "^2.2.0",
+        "open": "^7.4.2",
         "path2": "^0.1.0",
         "process-utils": "^4.0.0",
         "promise-queue": "^2.2.5",
@@ -22667,17 +22653,6 @@
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
         "debug": "^4.3.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
       }
     },
     "simple-swizzle": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "jest": "^27.3.1",
         "prettier": "^1.19.1",
         "ramda": "^0.27.1",
-        "serverless": "^2.66.1",
+        "serverless": "^2.70.0",
         "ts-jest": "^27.0.7",
         "tslint": "^5.20.1",
         "tslint-config-prettier": "^1.18.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "jest": "^27.3.1",
     "prettier": "^1.19.1",
     "ramda": "^0.27.1",
-    "serverless": "^2.70.0",
+    "serverless": "^2.71.0",
     "ts-jest": "^27.0.7",
     "tslint": "^5.20.1",
     "tslint-config-prettier": "^1.18.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "jest": "^27.3.1",
     "prettier": "^1.19.1",
     "ramda": "^0.27.1",
-    "serverless": "^2.66.1",
+    "serverless": "^2.70.0",
     "ts-jest": "^27.0.7",
     "tslint": "^5.20.1",
     "tslint-config-prettier": "^1.18.0",


### PR DESCRIPTION
Latest is now 2.71.0.

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>