### PR TITLE
Updating dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,33 +1,33 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-newrelic-lambda-layers",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fs-extra": "^10.0.0",
         "https-proxy-agent": "^5.0.0",
         "lodash": "^4.17.21",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.6.7",
         "path": "^0.12.7",
         "semver": "^7.3.5"
       },
       "devDependencies": {
         "@types/fs-extra": "^9.0.13",
-        "@types/jest": "^25.2.3",
+        "@types/jest": "^27.4.0",
         "@types/lodash": "^4.14.178",
         "@types/node": "^17.0.10",
-        "@types/node-fetch": "^2.5.7",
+        "@types/node-fetch": "^2.5.12",
         "@types/ramda": "^0.27.64",
-        "@types/serverless": "^1.78.42",
+        "@types/serverless": "^1.78.43",
         "get-installed-path": "^4.0.8",
-        "husky": "^4.3.0",
+        "husky": "^4.3.8",
         "jest": "^27.4.7",
-        "prettier": "^1.19.1",
+        "prettier": "^2.5.1",
         "ramda": "^0.28.0",
         "serverless": "^2.72.1",
         "ts-jest": "^27.1.3",
@@ -1864,115 +1864,14 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-      "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.0.tgz",
+      "integrity": "sha512-gHl8XuC1RZ8H2j5sHv/JqsaxXkDDM9iDOgu0Wp8sjs4u/snb2PVehyWXJPr+ORA0RPpgw231mnutWI1+0hgjIQ==",
       "dev": true,
       "dependencies": {
-        "jest-diff": "^25.2.1",
-        "pretty-format": "^25.2.1"
+        "jest-diff": "^27.0.0",
+        "pretty-format": "^27.0.0"
       }
-    },
-    "node_modules/@types/jest/node_modules/@jest/types": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-      "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-      "dev": true,
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^1.1.1",
-        "@types/yargs": "^15.0.0",
-        "chalk": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8.3"
-      }
-    },
-    "node_modules/@types/jest/node_modules/@types/istanbul-reports": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-      "dev": true,
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "*",
-        "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@types/jest/node_modules/@types/yargs": {
-      "version": "15.0.14",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
-      "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@types/jest/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@types/jest/node_modules/diff-sequences": {
-      "version": "25.2.6",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
-      "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8.3"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-diff": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
-      "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^3.0.0",
-        "diff-sequences": "^25.2.6",
-        "jest-get-type": "^25.2.6",
-        "pretty-format": "^25.5.0"
-      },
-      "engines": {
-        "node": ">= 8.3"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-get-type": {
-      "version": "25.2.6",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
-      "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8.3"
-      }
-    },
-    "node_modules/@types/jest/node_modules/pretty-format": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
-      "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^25.5.0",
-        "ansi-regex": "^5.0.0",
-        "ansi-styles": "^4.0.0",
-        "react-is": "^16.12.0"
-      },
-      "engines": {
-        "node": ">= 8.3"
-      }
-    },
-    "node_modules/@types/jest/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
     },
     "node_modules/@types/keyv": {
       "version": "3.1.3",
@@ -2091,9 +1990,9 @@
       }
     },
     "node_modules/@types/serverless": {
-      "version": "1.78.42",
-      "resolved": "https://registry.npmjs.org/@types/serverless/-/serverless-1.78.42.tgz",
-      "integrity": "sha512-XFrgbkqX4C1ZLHhufmfRJRc74eSDleAP+mgEMPvNSCDOvn5Gj1KnDEhE1CoikDpWctv/VZFfLjs75Zr1H8upNQ==",
+      "version": "1.78.43",
+      "resolved": "https://registry.npmjs.org/@types/serverless/-/serverless-1.78.43.tgz",
+      "integrity": "sha512-Yz/MGJVu8w8hbpsT8oCBw1Amy7rRN92dHTXBdL7mJhmZnLY4UODW4UakB4MRJ4/ADerMwE9zJ2mr0+ySzumjVg==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -7514,15 +7413,16 @@
       "dev": true
     },
     "node_modules/ncjsm": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ncjsm/-/ncjsm-4.2.0.tgz",
-      "integrity": "sha512-L2Qij4PTy7Bs4TB24zs7FLIAYJTaR5JPvSig5hIcO059LnMCNgy6MfHHNyg8s/aekPKrTqKX90gBGt3NNGvhdw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ncjsm/-/ncjsm-4.3.0.tgz",
+      "integrity": "sha512-oah6YGwb4Ern2alojiMFcjPhE4wvQBw1Ur/kUr2P0ovKdzaF5pCIsGjs0f2y+iZeej0/5Y6OOhQ8j30cTDMEGw==",
       "dev": true,
       "dependencies": {
         "builtin-modules": "^3.2.0",
         "deferred": "^0.7.11",
         "es5-ext": "^0.10.53",
         "es6-set": "^0.1.5",
+        "ext": "^1.6.0",
         "find-requires": "^1.0.0",
         "fs2": "^0.3.9",
         "type": "^2.5.0"
@@ -8437,15 +8337,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/pretty-format": {
@@ -9164,9 +9064,9 @@
       }
     },
     "node_modules/serverless": {
-      "version": "2.72.1",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-2.72.1.tgz",
-      "integrity": "sha512-SxmxyBgWQvcKvEXdP0fR3Y+nljOQ+nWCPDZXnhic//w+k0kNQ/bHcd3S1VZQqU3m7nZZwMsdC5lxB26EpUFELA==",
+      "version": "2.72.2",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-2.72.2.tgz",
+      "integrity": "sha512-xlxaWyq4b58DIX3prwIikBmXj0z4R+YI9zcDPYgQc78mKJ0qTgCK7BMoy6dlVuHXnfhBkhT3uT/EhFvjKIdk6g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -9178,7 +9078,7 @@
         "ajv": "^6.12.6",
         "ajv-keywords": "^3.5.2",
         "archiver": "^5.3.0",
-        "aws-sdk": "^2.1061.0",
+        "aws-sdk": "^2.1062.0",
         "bluebird": "^3.7.2",
         "boxen": "^5.1.2",
         "cachedir": "^2.3.0",
@@ -9208,7 +9108,7 @@
         "lodash": "^4.17.21",
         "memoizee": "^0.4.15",
         "micromatch": "^4.0.4",
-        "ncjsm": "^4.2.0",
+        "ncjsm": "^4.3.0",
         "node-fetch": "^2.6.7",
         "open": "^7.4.2",
         "path2": "^0.1.0",
@@ -12904,98 +12804,13 @@
       }
     },
     "@types/jest": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-      "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.0.tgz",
+      "integrity": "sha512-gHl8XuC1RZ8H2j5sHv/JqsaxXkDDM9iDOgu0Wp8sjs4u/snb2PVehyWXJPr+ORA0RPpgw231mnutWI1+0hgjIQ==",
       "dev": true,
       "requires": {
-        "jest-diff": "^25.2.1",
-        "pretty-format": "^25.2.1"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^3.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-          "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "*",
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "@types/yargs": {
-          "version": "15.0.14",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
-          "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "diff-sequences": {
-          "version": "25.2.6",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
-          "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
-          "dev": true
-        },
-        "jest-diff": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
-          "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
-          "dev": true,
-          "requires": {
-            "chalk": "^3.0.0",
-            "diff-sequences": "^25.2.6",
-            "jest-get-type": "^25.2.6",
-            "pretty-format": "^25.5.0"
-          }
-        },
-        "jest-get-type": {
-          "version": "25.2.6",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
-          "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
-          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^25.5.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
-          }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-          "dev": true
-        }
+        "jest-diff": "^27.0.0",
+        "pretty-format": "^27.0.0"
       }
     },
     "@types/keyv": {
@@ -13113,9 +12928,9 @@
       }
     },
     "@types/serverless": {
-      "version": "1.78.42",
-      "resolved": "https://registry.npmjs.org/@types/serverless/-/serverless-1.78.42.tgz",
-      "integrity": "sha512-XFrgbkqX4C1ZLHhufmfRJRc74eSDleAP+mgEMPvNSCDOvn5Gj1KnDEhE1CoikDpWctv/VZFfLjs75Zr1H8upNQ==",
+      "version": "1.78.43",
+      "resolved": "https://registry.npmjs.org/@types/serverless/-/serverless-1.78.43.tgz",
+      "integrity": "sha512-Yz/MGJVu8w8hbpsT8oCBw1Amy7rRN92dHTXBdL7mJhmZnLY4UODW4UakB4MRJ4/ADerMwE9zJ2mr0+ySzumjVg==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -17456,15 +17271,16 @@
       "dev": true
     },
     "ncjsm": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ncjsm/-/ncjsm-4.2.0.tgz",
-      "integrity": "sha512-L2Qij4PTy7Bs4TB24zs7FLIAYJTaR5JPvSig5hIcO059LnMCNgy6MfHHNyg8s/aekPKrTqKX90gBGt3NNGvhdw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ncjsm/-/ncjsm-4.3.0.tgz",
+      "integrity": "sha512-oah6YGwb4Ern2alojiMFcjPhE4wvQBw1Ur/kUr2P0ovKdzaF5pCIsGjs0f2y+iZeej0/5Y6OOhQ8j30cTDMEGw==",
       "dev": true,
       "requires": {
         "builtin-modules": "^3.2.0",
         "deferred": "^0.7.11",
         "es5-ext": "^0.10.53",
         "es6-set": "^0.1.5",
+        "ext": "^1.6.0",
         "find-requires": "^1.0.0",
         "fs2": "^0.3.9",
         "type": "^2.5.0"
@@ -18178,9 +17994,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true
     },
     "pretty-format": {
@@ -18693,9 +18509,9 @@
       "dev": true
     },
     "serverless": {
-      "version": "2.72.1",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-2.72.1.tgz",
-      "integrity": "sha512-SxmxyBgWQvcKvEXdP0fR3Y+nljOQ+nWCPDZXnhic//w+k0kNQ/bHcd3S1VZQqU3m7nZZwMsdC5lxB26EpUFELA==",
+      "version": "2.72.2",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-2.72.2.tgz",
+      "integrity": "sha512-xlxaWyq4b58DIX3prwIikBmXj0z4R+YI9zcDPYgQc78mKJ0qTgCK7BMoy6dlVuHXnfhBkhT3uT/EhFvjKIdk6g==",
       "dev": true,
       "requires": {
         "@serverless/cli": "^1.6.0",
@@ -18706,7 +18522,7 @@
         "ajv": "^6.12.6",
         "ajv-keywords": "^3.5.2",
         "archiver": "^5.3.0",
-        "aws-sdk": "^2.1061.0",
+        "aws-sdk": "^2.1062.0",
         "bluebird": "^3.7.2",
         "boxen": "^5.1.2",
         "cachedir": "^2.3.0",
@@ -18736,7 +18552,7 @@
         "lodash": "^4.17.21",
         "memoizee": "^0.4.15",
         "micromatch": "^4.0.4",
-        "ncjsm": "^4.2.0",
+        "ncjsm": "^4.3.0",
         "node-fetch": "^2.6.7",
         "open": "^7.4.2",
         "path2": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [
@@ -33,16 +33,16 @@
   "homepage": "https://github.com/iopipe/serverless-newrelic-lambda-layers#readme",
   "devDependencies": {
     "@types/fs-extra": "^9.0.13",
-    "@types/jest": "^25.2.3",
+    "@types/jest": "^27.4.0",
     "@types/lodash": "^4.14.178",
     "@types/node": "^17.0.10",
-    "@types/node-fetch": "^2.5.7",
+    "@types/node-fetch": "^2.5.12",
     "@types/ramda": "^0.27.64",
-    "@types/serverless": "^1.78.42",
+    "@types/serverless": "^1.78.43",
     "get-installed-path": "^4.0.8",
-    "husky": "^4.3.0",
+    "husky": "^4.3.8",
     "jest": "^27.4.7",
-    "prettier": "^1.19.1",
+    "prettier": "^2.5.1",
     "ramda": "^0.28.0",
     "serverless": "^2.72.1",
     "ts-jest": "^27.1.3",
@@ -56,7 +56,7 @@
     "fs-extra": "^10.0.0",
     "https-proxy-agent": "^5.0.0",
     "lodash": "^4.17.21",
-    "node-fetch": "^2.6.1",
+    "node-fetch": "^2.6.7",
     "path": "^0.12.7",
     "semver": "^7.3.5"
   },

--- a/src/api.ts
+++ b/src/api.ts
@@ -23,10 +23,10 @@ export const nerdgraphFetch = async (
     body: JSON.stringify({ query }),
     headers: {
       "API-Key": apiKey,
-      "Content-Type": "application/json"
+      "Content-Type": "application/json",
     },
-    method: "POST"
-  }).catch(e => {
+    method: "POST",
+  }).catch((e) => {
     context.serverless.log(`Error fetching from NerdGraph; ${context.caller}`);
     context.serverless.log.log(e);
     return null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,12 +11,12 @@ const DEFAULT_FILTER_PATTERNS = [
   "REPORT",
   "NR_LAMBDA_MONITORING",
   "Task timed out",
-  "RequestId"
+  "RequestId",
 ];
 
 const enum JavaHandler {
   handleRequest = "handleRequest",
-  handleStreamsRequest = "handleStreamsRequest"
+  handleStreamsRequest = "handleStreamsRequest",
 }
 
 export default class NewRelicLambdaLayerPlugin {
@@ -49,7 +49,7 @@ export default class NewRelicLambdaLayerPlugin {
           "before:deploy:deploy": this.checkIntegration.bind(this),
           "before:deploy:function:packageFunction": this.run.bind(this),
           "before:package:createDeploymentArtifacts": this.run.bind(this),
-          "before:remove:remove": this.removeLogSubscriptions.bind(this)
+          "before:remove:remove": this.removeLogSubscriptions.bind(this),
         };
   }
 
@@ -59,7 +59,7 @@ export default class NewRelicLambdaLayerPlugin {
 
   get config() {
     return _.get(this.serverless, "service.custom.newRelic", {
-      nrRegion: "us"
+      nrRegion: "us",
     });
   }
 
@@ -123,7 +123,7 @@ export default class NewRelicLambdaLayerPlugin {
       null,
       this.serverless.service
         .getAllFunctions()
-        .map(func => ({ [func]: this.serverless.service.getFunction(func) }))
+        .map((func) => ({ [func]: this.serverless.service.getFunction(func) }))
     );
   }
 
@@ -196,7 +196,7 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
       } else if (this.managedSecretConfigured) {
         this.mgdPolicyArns = [
           ...this.managedPolicyArns,
-          managedSecret.policyArn
+          managedSecret.policyArn,
         ];
       }
     }
@@ -265,9 +265,9 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
       const resources = this.resources;
       Object.keys(resources)
         .filter(
-          resourceName => resources[resourceName].Type === `AWS::IAM::Role`
+          (resourceName) => resources[resourceName].Type === `AWS::IAM::Role`
         )
-        .forEach(roleResource =>
+        .forEach((roleResource) =>
           this.applyPolicies(resources[roleResource].Properties)
         );
     }
@@ -303,7 +303,7 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
       typeof cloudWatchFilter === "object" &&
       cloudWatchFilter.indexOf("*") === -1
     ) {
-      cloudWatchFilter = cloudWatchFilter.map(el => `?\"${el}\"`);
+      cloudWatchFilter = cloudWatchFilter.map((el) => `?\"${el}\"`);
       cloudWatchFilterString = cloudWatchFilter.join(" ");
     } else if (cloudWatchFilter.indexOf("*") === -1) {
       cloudWatchFilterString = String(cloudWatchFilter);
@@ -377,7 +377,7 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
         null
       ),
       layers = [],
-      package: pkg = {}
+      package: pkg = {},
     } = funcDef;
 
     if (!this.config.accountId && !environment.NEW_RELIC_ACCOUNT_ID) {
@@ -396,7 +396,7 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
         "python3.8",
         "python3.9",
         "java11",
-        "java8.al2"
+        "java8.al2",
       ].indexOf(runtime) === -1;
 
     if (
@@ -422,7 +422,7 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
     }
 
     const newRelicLayers = layers.filter(
-      layer => typeof layer === "string" && layer.match(layerArn)
+      (layer) => typeof layer === "string" && layer.match(layerArn)
     );
 
     // Note: This is if the user specifies a layer in their serverless.yml
@@ -462,11 +462,12 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
       environment.NEW_RELIC_DISTRIBUTED_TRACING_ENABLED = "true";
     }
 
-    environment.NEW_RELIC_TRUSTED_ACCOUNT_KEY = environment.NEW_RELIC_TRUSTED_ACCOUNT_KEY
-      ? environment.NEW_RELIC_TRUSTED_ACCOUNT_KEY
-      : this.config.trustedAccountKey
-      ? this.config.trustedAccountKey
-      : environment.NEW_RELIC_ACCOUNT_ID;
+    environment.NEW_RELIC_TRUSTED_ACCOUNT_KEY =
+      environment.NEW_RELIC_TRUSTED_ACCOUNT_KEY
+        ? environment.NEW_RELIC_TRUSTED_ACCOUNT_KEY
+        : this.config.trustedAccountKey
+        ? this.config.trustedAccountKey
+        : environment.NEW_RELIC_ACCOUNT_ID;
 
     if (runtime.match("python")) {
       environment.NEW_RELIC_SERVERLESS_MODE_ENABLED = "true";
@@ -555,11 +556,11 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
   private async getLayerArn(runtime: string, architecture?: string) {
     const url = `https://${this.region}.layers.newrelic-external.com/get-layers?CompatibleRuntime=${runtime}`;
     return fetch(url)
-      .then(async response => {
+      .then(async (response) => {
         const awsResp = await response.json();
         const layers = _.get(awsResp, "Layers", []);
         const compatibleLayers = layers
-          .map(layer => {
+          .map((layer) => {
             const latestLayer = layer.LatestMatchingVersion;
             const latestArch = latestLayer.CompatibleArchitectures;
             const matchingArch =
@@ -571,7 +572,7 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
               return latestLayer;
             }
           })
-          .filter(layer => typeof layer !== "undefined");
+          .filter((layer) => typeof layer !== "undefined");
 
         if (
           !compatibleLayers ||
@@ -584,7 +585,7 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
         }
         return compatibleLayers[0].LayerVersionArn;
       })
-      .catch(reason => {
+      .catch((reason) => {
         this.serverless.cli.log(
           `Unable to get layer ARN for ${runtime} in ${this.region}`
         );
@@ -627,7 +628,7 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
   ) {
     try {
       await this.awsProvider.request("Lambda", "getFunction", {
-        FunctionName: funcName
+        FunctionName: funcName,
       });
     } catch (err) {
       if (err.providerError) {
@@ -638,10 +639,8 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
 
     let destinationArn;
 
-    const {
-      logIngestionFunctionName = "newrelic-log-ingestion",
-      apiKey
-    } = this.config;
+    const { logIngestionFunctionName = "newrelic-log-ingestion", apiKey } =
+      this.config;
 
     try {
       destinationArn = await this.getDestinationArn(logIngestionFunctionName);
@@ -681,7 +680,7 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
     }
 
     const competingFilters = subscriptionFilters.filter(
-      filter => filter.filterName !== "NewRelicLogStreaming"
+      (filter) => filter.filterName !== "NewRelicLogStreaming"
     );
 
     if (competingFilters.length) {
@@ -691,7 +690,7 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
     }
 
     const existingFilters = subscriptionFilters.filter(
-      filter => filter.filterName === "NewRelicLogStreaming"
+      (filter) => filter.filterName === "NewRelicLogStreaming"
     );
 
     if (existingFilters.length) {
@@ -701,9 +700,9 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
 
       await Promise.all(
         existingFilters
-          .filter(filter => filter.filterPattern !== cloudWatchFilterString)
-          .map(async filter => this.removeSubscriptionFilter(funcName))
-          .map(async filter =>
+          .filter((filter) => filter.filterPattern !== cloudWatchFilterString)
+          .map(async (filter) => this.removeSubscriptionFilter(funcName))
+          .map(async (filter) =>
             this.addSubscriptionFilter(
               funcName,
               destinationArn,
@@ -728,9 +727,9 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
     try {
       return this.awsProvider
         .request("Lambda", "getFunction", {
-          FunctionName: logIngestionFunctionName
+          FunctionName: logIngestionFunctionName,
         })
-        .then(res => res.Configuration.FunctionArn);
+        .then((res) => res.Configuration.FunctionArn);
     } catch (e) {
       this.serverless.cli.log(
         `Error getting ingestion function destination ARN.`
@@ -760,7 +759,7 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
         ChangeSetType: mode,
         Parameters: parameters,
         StackName: stackName,
-        TemplateURL: templateUrl
+        TemplateURL: templateUrl,
       };
 
       let cfResponse;
@@ -785,7 +784,7 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
           awsMethod: "describeChangeSet",
           callbackMethod: () => this.executeChangeSet(Id, StackId),
           methodParams: { ChangeSetName: Id },
-          statusPath: "Status"
+          statusPath: "Status",
         },
         this
       );
@@ -819,12 +818,12 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
     return [
       {
         ParameterKey: "NRLoggingEnabled",
-        ParameterValue: `${loggingVar}`
+        ParameterValue: `${loggingVar}`,
       },
       {
         ParameterKey: "NRLicenseKey",
-        ParameterValue: `${licenseKey}`
-      }
+        ParameterValue: `${licenseKey}`,
+      },
     ];
   }
 
@@ -835,7 +834,7 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
         "createCloudFormationTemplate",
         {
           ApplicationId:
-            "arn:aws:serverlessrepo:us-east-1:463657938898:applications/NewRelic-log-ingestion"
+            "arn:aws:serverlessrepo:us-east-1:463657938898:applications/NewRelic-log-ingestion",
         }
       );
 
@@ -851,7 +850,7 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
   private async executeChangeSet(changeSetName: string, stackId: string) {
     try {
       await this.awsProvider.request("CloudFormation", "executeChangeSet", {
-        ChangeSetName: changeSetName
+        ChangeSetName: changeSetName,
       });
       this.serverless.cli.log(
         "Waiting for newrelic-log-ingestion install to complete, this may take a minute..."
@@ -862,7 +861,7 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
           awsMethod: "describeStacks",
           callbackMethod: () => this.addLogSubscriptions(),
           methodParams: { StackName: stackId },
-          statusPath: "Stacks[0].StackStatus"
+          statusPath: "Stacks[0].StackStatus",
         },
         this
       );
@@ -876,9 +875,9 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
   private async describeSubscriptionFilters(funcName: string) {
     return this.awsProvider
       .request("CloudWatchLogs", "describeSubscriptionFilters", {
-        logGroupName: `/aws/lambda/${funcName}`
+        logGroupName: `/aws/lambda/${funcName}`,
       })
-      .then(res => res.subscriptionFilters);
+      .then((res) => res.subscriptionFilters);
   }
 
   private async addSubscriptionFilter(
@@ -891,9 +890,9 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
         destinationArn,
         filterName: "NewRelicLogStreaming",
         filterPattern: cloudWatchFilterString,
-        logGroupName: `/aws/lambda/${funcName}`
+        logGroupName: `/aws/lambda/${funcName}`,
       })
-      .catch(err => {
+      .catch((err) => {
         if (err.providerError) {
           this.serverless.cli.log(err.providerError.message);
         }
@@ -904,9 +903,9 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
     return this.awsProvider
       .request("CloudWatchLogs", "DeleteSubscriptionFilter", {
         filterName: "NewRelicLogStreaming",
-        logGroupName: `/aws/lambda/${funcName}`
+        logGroupName: `/aws/lambda/${funcName}`,
       })
-      .catch(err => {
+      .catch((err) => {
         if (err.providerError) {
           this.serverless.cli.log(err.providerError.message);
         }

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -3,7 +3,7 @@ import {
   cloudLinkAccountMutation,
   cloudServiceIntegrationMutation,
   fetchLinkedAccounts,
-  nerdgraphFetch
+  nerdgraphFetch,
 } from "./api";
 import { fetchPolicy, waitForStatus } from "./utils";
 
@@ -23,13 +23,8 @@ export default class Integration {
   }
 
   public async check() {
-    const {
-      accountId,
-      enableIntegration,
-      apiKey,
-      nrRegion,
-      proxy
-    } = this.config;
+    const { accountId, enableIntegration, apiKey, nrRegion, proxy } =
+      this.config;
 
     const integrationData = await nerdgraphFetch(
       apiKey,
@@ -38,7 +33,7 @@ export default class Integration {
       proxy,
       {
         caller: "check integration for linked accounts",
-        serverless: this.serverless
+        serverless: this.serverless,
       }
     );
 
@@ -50,7 +45,7 @@ export default class Integration {
 
     const externalId = await this.getCallerIdentity();
 
-    const match = linkedAccounts.filter(account => {
+    const match = linkedAccounts.filter((account) => {
       return (
         account.externalId === externalId &&
         account.nrAccountId === parseInt(accountId, 10)
@@ -80,11 +75,11 @@ export default class Integration {
 
   public async checkForManagedSecretPolicy() {
     const thisRegionPolicy = `NewRelic-ViewLicenseKey-${this.region}`;
-    const regionFilter = policy => policy.PolicyName.match(thisRegionPolicy);
+    const regionFilter = (policy) => policy.PolicyName.match(thisRegionPolicy);
 
     try {
       const params = {
-        Scope: `Local`
+        Scope: `Local`,
       };
 
       const results = await this.awsProvider.request(
@@ -95,7 +90,7 @@ export default class Integration {
       const currentRegionPolicy = results.Policies.filter(regionFilter);
       return {
         currentRegionPolicy,
-        secretExists: currentRegionPolicy.length > 0
+        secretExists: currentRegionPolicy.length > 0,
       };
     } catch (err) {
       this.serverless.cli.log(
@@ -117,19 +112,19 @@ export default class Integration {
         Parameters: [
           {
             ParameterKey: "LicenseKey",
-            ParameterValue: this.licenseKey
+            ParameterValue: this.licenseKey,
           },
           {
             ParameterKey: "Region",
-            ParameterValue: this.region
+            ParameterValue: this.region,
           },
           {
             ParameterKey: "PolicyName",
-            ParameterValue: policyName
-          }
+            ParameterValue: policyName,
+          },
         ],
         StackName: stackName,
-        TemplateBody: policy
+        TemplateBody: policy,
       };
 
       const { StackId } = await this.awsProvider.request(
@@ -166,9 +161,8 @@ export default class Integration {
       }
 
       const { accountId, apiKey, nrRegion, proxy } = this.config;
-      const {
-        linkedAccount = `New Relic Lambda Integration - ${accountId}`
-      } = this.config;
+      const { linkedAccount = `New Relic Lambda Integration - ${accountId}` } =
+        this.config;
 
       this.serverless.cli.log(
         `Enabling New Relic integration for linked account: ${linkedAccount} and aws account: ${externalId}.`
@@ -181,12 +175,12 @@ export default class Integration {
         proxy,
         {
           caller: "enable integration, cloudLinkAccountMutation",
-          serverless: this.serverless
+          serverless: this.serverless,
         }
       );
 
       const { linkedAccounts, errors } = _.get(res, "data.cloudLinkAccount", {
-        errors: ["data.cloudLinkAccount missing in response"]
+        errors: ["data.cloudLinkAccount missing in response"],
       });
 
       if (errors && errors.length) {
@@ -206,7 +200,7 @@ export default class Integration {
         proxy,
         {
           caller: "enable integration, cloudServiceIntegrationMutation",
-          serverless: this.serverless
+          serverless: this.serverless,
         }
       );
 
@@ -214,7 +208,7 @@ export default class Integration {
         integrationRes,
         "data.cloudConfigureIntegration",
         {
-          errors: ["data.cloudConfigureIntegration missing in response"]
+          errors: ["data.cloudConfigureIntegration missing in response"],
         }
       );
 
@@ -249,12 +243,12 @@ export default class Integration {
 
   private async requestRoleArn(RoleName: string) {
     const params = {
-      RoleName
+      RoleName,
     };
     const response = await this.awsProvider.request("IAM", "getRole", params);
 
     const {
-      Role: { Arn }
+      Role: { Arn },
     } = response;
 
     return Arn;
@@ -286,9 +280,9 @@ export default class Integration {
             awsMethod: "describeStacks",
             callbackMethod: () => this.enable(externalId),
             methodParams: {
-              StackName: stackId
+              StackName: stackId,
             },
-            statusPath: "Stacks[0].StackStatus"
+            statusPath: "Stacks[0].StackStatus",
           },
           this
         );
@@ -307,12 +301,12 @@ export default class Integration {
         Parameters: [
           {
             ParameterKey: "NewRelicAccountNumber",
-            ParameterValue: accountId.toString()
+            ParameterValue: accountId.toString(),
           },
-          { ParameterKey: "PolicyName", ParameterValue: customRolePolicy }
+          { ParameterKey: "PolicyName", ParameterValue: customRolePolicy },
         ],
         StackName: stackName,
-        TemplateBody: policy
+        TemplateBody: policy,
       };
 
       const { StackId } = await this.awsProvider.request(


### PR DESCRIPTION
node-fetch 2.6.7 is patched.

Prettier.js is updated, and has slight API changes that require some changes to code style: trailing commas and parens around the param of single-param arrow functions. This gets us up to date with Prettier. 

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>