### PR TITLE
Check for Serverless 3.x and provide a fallback logging interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -231,6 +231,13 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
         `Serverless ${version} does not support layers. Please upgrade to >=1.34.0.`
       );
       return;
+    } else if (semver.lt(version, "3.0.0")) {
+      this.log.error(
+        `Serverless ${version} and Serverless >= 3.0.0 have some incompatibilities in logging.  
+        This plugin is optimized for Serverless 3.x. Please upgrade Serverless to >=3.0.0, 
+        or use version 2.4.1 of this plugin.`
+      );
+      return;
     }
 
     let plugins = _.get(this.serverless, "service.plugins", []);

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,15 +227,16 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
   public async run() {
     const version = this.serverless.getVersion();
     if (semver.lt(version, "1.34.0")) {
-      this.log.error(
+      // tslint:disable-next-line
+      console.error(
         `Serverless ${version} does not support layers. Please upgrade to >=1.34.0.`
       );
       return;
     } else if (semver.lt(version, "3.0.0")) {
-      this.log.error(
-        `Serverless ${version} and Serverless >= 3.0.0 have some incompatibilities in logging.  
-        This plugin is optimized for Serverless 3.x. Please upgrade Serverless to >=3.0.0, 
-        or use version 2.4.1 of this plugin.`
+      // tslint:disable-next-line
+      console.error(
+        `Serverless 3.0.0 changed its logging interface, and is incompatible with Serverless ${version}.   
+        This plugin requires Serverless 3.x. Please upgrade Serverless to >=3.0.0, or use version 2.4.1 of this plugin.`
       );
       return;
     }

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -62,7 +62,7 @@ export default class Integration {
     });
 
     if (match.length < 1) {
-      this.log.warn(
+      this.log.warning(
         "No New Relic AWS Lambda integration found for this New Relic linked account and aws account."
       );
 


### PR DESCRIPTION
Serverless 3.x introduced a breaking change for logging. Some customers are using the latest plugin with Serverless 2.x, so for that case, this PR would print a warning. 

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>