### PR TITLE
Support Node 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ This plugin currently supports the following AWS runtimes:
 
 - nodejs12.x
 - nodejs14.x
+- nodejs16.x
 - python3.6
 - python3.7
 - python3.8

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-newrelic-lambda-layers",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/fs-extra": "^9.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ const logShim = {
 const wrappableRuntimeList = [
   "nodejs12.x",
   "nodejs14.x",
+  "nodejs16.x",
   "python3.6",
   "python3.7",
   "python3.8",
@@ -707,7 +708,7 @@ or make sure that you already have Serverless 3.x installed in your project.
   }
 
   private getHandlerWrapper(runtime: string, handler: string) {
-    if (["nodejs12.x", "nodejs14.x"].indexOf(runtime) !== -1) {
+    if (["nodejs12.x", "nodejs14.x", "nodejs16.x"].indexOf(runtime) !== -1) {
       return "newrelic-lambda-wrapper.handler";
     }
 

--- a/tests/fixtures/arm64.output.service.json
+++ b/tests/fixtures/arm64.output.service.json
@@ -24,7 +24,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12XARM64:20"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12XARM64:30"
       ],
       "package": {
         "exclude": [
@@ -52,7 +52,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14XARM64:19"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14XARM64:29"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/debug-log-level.output.service.json
+++ b/tests/fixtures/debug-log-level.output.service.json
@@ -32,7 +32,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:75"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -53,7 +53,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/debug.input.service.json
+++ b/tests/fixtures/debug.input.service.json
@@ -38,6 +38,12 @@
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
       "runtime": "nodejs14.x"
+    },
+    "layer-nodejs16x": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs16.x"
     }
   }
 }

--- a/tests/fixtures/debug.output.service.json
+++ b/tests/fixtures/debug.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:75"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -44,7 +44,7 @@
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
         "NEW_RELIC_LOG_LEVEL": "debug",
-           "NEW_RELIC_NO_CONFIG_FILE": "true",
+        "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       }
     },
@@ -52,7 +52,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -65,7 +65,28 @@
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
         "NEW_RELIC_LOG_LEVEL": "debug",
-           "NEW_RELIC_NO_CONFIG_FILE": "true",
+        "NEW_RELIC_NO_CONFIG_FILE": "true",
+        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
+      }
+    },
+    "layer-nodejs16x": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "newrelic-lambda-wrapper.handler",
+      "layers": [
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:2"
+      ],
+      "package": {
+        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
+        "include": ["handler.js"]
+      },
+      "runtime": "nodejs16.x",
+      "environment": {
+        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
+        "NEW_RELIC_APP_NAME": "layer-nodejs16x",
+        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
+        "NEW_RELIC_LOG": "stdout",
+        "NEW_RELIC_LOG_LEVEL": "debug",
+        "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       }
     }

--- a/tests/fixtures/distributed-tracing-enabled.output.service.json
+++ b/tests/fixtures/distributed-tracing-enabled.output.service.json
@@ -35,7 +35,7 @@
   "plugins": ["serverless-newrelic-lambda-layers"],
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:75"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
     ],
     "name": "aws",
     "region": "us-east-1",

--- a/tests/fixtures/eu.output.service.json
+++ b/tests/fixtures/eu.output.service.json
@@ -28,7 +28,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:75"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -53,7 +53,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/include.output.service.json
+++ b/tests/fixtures/include.output.service.json
@@ -43,7 +43,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers":  [
-           "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:45"
+           "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
        ],
       "package": { "exclude": [
         "./**",

--- a/tests/fixtures/includes-all-provider-layer.output.service.json
+++ b/tests/fixtures/includes-all-provider-layer.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:75"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
     ],
     "name": "aws",
     "stage": "prod",

--- a/tests/fixtures/lambda-extension-disabled.output.service.json
+++ b/tests/fixtures/lambda-extension-disabled.output.service.json
@@ -25,7 +25,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:75"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -49,7 +49,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/lambda-extension-enabled.output.service.json
+++ b/tests/fixtures/lambda-extension-enabled.output.service.json
@@ -24,7 +24,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:75"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -47,7 +47,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/license-key-secret-disabled.output.service.json
+++ b/tests/fixtures/license-key-secret-disabled.output.service.json
@@ -25,7 +25,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:75"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
       ],
       "package": {
         "exclude": [
@@ -53,7 +53,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-disabled.output.service.json
+++ b/tests/fixtures/log-disabled.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:75"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -50,7 +50,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/log-ingestion-via-extension.output.service.json
+++ b/tests/fixtures/log-ingestion-via-extension.output.service.json
@@ -28,7 +28,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:75"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
       ],
       "package": {
         "exclude": [
@@ -57,7 +57,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-level.output.service.json
+++ b/tests/fixtures/log-level.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:75"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -52,7 +52,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment-log-level.output.service.json
+++ b/tests/fixtures/provider-environment-log-level.output.service.json
@@ -34,7 +34,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:75"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -55,7 +55,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment.output.service.json
+++ b/tests/fixtures/provider-environment.output.service.json
@@ -33,7 +33,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:75"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -54,7 +54,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-layer.output.service.json
+++ b/tests/fixtures/provider-layer.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:75"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
     ],
     "name": "aws",
     "stage": "prod",

--- a/tests/fixtures/proxy.output.service.json
+++ b/tests/fixtures/proxy.output.service.json
@@ -24,7 +24,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:75"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
       ],
       "package": {
         "exclude": [
@@ -52,7 +52,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/stage-included.output.service.json
+++ b/tests/fixtures/stage-included.output.service.json
@@ -30,7 +30,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:75"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -49,7 +49,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/trusted-account-key-excluded.output.service.json
+++ b/tests/fixtures/trusted-account-key-excluded.output.service.json
@@ -29,7 +29,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:75"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -48,7 +48,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/trusted-account-key-included.output.service.json
+++ b/tests/fixtures/trusted-account-key-included.output.service.json
@@ -30,7 +30,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:75"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -49,7 +49,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:45"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],


### PR DESCRIPTION
Now that Node 16 layers are out, here's support from the plugin (with updated snapshots and one test with Node 16 as the target.)

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>