### PR TITLE
Restoring NEW_RELIC_LOG_ENABLED env var

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-newrelic-lambda-layers",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/fs-extra": "^9.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -643,6 +643,10 @@ or make sure that you already have Serverless 3.x installed in your project.
   }
 
   private logLevel(environment) {
+    environment.NEW_RELIC_LOG_ENABLED = environment.NEW_RELIC_LOG_ENABLED
+      ? environment.NEW_RELIC_LOG_ENABLED
+      : "true";
+
     environment.NEW_RELIC_LOG = environment.NEW_RELIC_LOG
       ? environment.NEW_RELIC_LOG
       : "stdout";

--- a/tests/fixtures/arm64.output.service.json
+++ b/tests/fixtures/arm64.output.service.json
@@ -24,7 +24,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12XARM64:30"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12XARM64:31"
       ],
       "package": {
         "exclude": [
@@ -52,7 +52,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14XARM64:29"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14XARM64:30"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/debug-log-level.output.service.json
+++ b/tests/fixtures/debug-log-level.output.service.json
@@ -32,7 +32,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:86"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -44,8 +44,9 @@
         "NEW_RELIC_APP_NAME": "layer-nodejs12x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
+        "NEW_RELIC_LOG_ENABLED": "true",
         "NEW_RELIC_LOG_LEVEL": "error",
-           "NEW_RELIC_NO_CONFIG_FILE": "true",
+        "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       }
     },
@@ -53,7 +54,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:56"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -65,8 +66,9 @@
         "NEW_RELIC_APP_NAME": "layer-nodejs14x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
+        "NEW_RELIC_LOG_ENABLED": "true",
         "NEW_RELIC_LOG_LEVEL": "error",
-           "NEW_RELIC_NO_CONFIG_FILE": "true",
+        "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       }
     }

--- a/tests/fixtures/debug.output.service.json
+++ b/tests/fixtures/debug.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:86"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -43,6 +43,7 @@
         "NEW_RELIC_APP_NAME": "layer-nodejs12x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
+        "NEW_RELIC_LOG_ENABLED": "true",
         "NEW_RELIC_LOG_LEVEL": "debug",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
@@ -52,7 +53,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:56"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -64,6 +65,7 @@
         "NEW_RELIC_APP_NAME": "layer-nodejs14x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
+        "NEW_RELIC_LOG_ENABLED": "true",
         "NEW_RELIC_LOG_LEVEL": "debug",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
@@ -73,7 +75,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:2"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:3"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -85,6 +87,7 @@
         "NEW_RELIC_APP_NAME": "layer-nodejs16x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
+        "NEW_RELIC_LOG_ENABLED": "true",
         "NEW_RELIC_LOG_LEVEL": "debug",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"

--- a/tests/fixtures/distributed-tracing-enabled.output.service.json
+++ b/tests/fixtures/distributed-tracing-enabled.output.service.json
@@ -35,7 +35,7 @@
   "plugins": ["serverless-newrelic-lambda-layers"],
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:86"
     ],
     "name": "aws",
     "region": "us-east-1",

--- a/tests/fixtures/eu.output.service.json
+++ b/tests/fixtures/eu.output.service.json
@@ -17,7 +17,8 @@
         "NEW_RELIC_APP_NAME": "layer-nodejs12x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
-           "NEW_RELIC_LOG_LEVEL": "debug",
+        "NEW_RELIC_LOG_ENABLED": "true",
+        "NEW_RELIC_LOG_LEVEL": "debug",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       },
@@ -28,7 +29,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:86"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -42,7 +43,8 @@
         "NEW_RELIC_APP_NAME": "layer-nodejs14x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
-           "NEW_RELIC_LOG_LEVEL": "debug",
+        "NEW_RELIC_LOG_ENABLED": "true",
+        "NEW_RELIC_LOG_LEVEL": "debug",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       },
@@ -53,7 +55,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:56"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/include.output.service.json
+++ b/tests/fixtures/include.output.service.json
@@ -43,7 +43,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers":  [
-           "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
+           "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:56"
        ],
       "package": { "exclude": [
         "./**",

--- a/tests/fixtures/includes-all-provider-layer.output.service.json
+++ b/tests/fixtures/includes-all-provider-layer.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:86"
     ],
     "name": "aws",
     "stage": "prod",

--- a/tests/fixtures/lambda-extension-disabled.output.service.json
+++ b/tests/fixtures/lambda-extension-disabled.output.service.json
@@ -25,7 +25,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:86"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -49,7 +49,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:56"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/lambda-extension-enabled.output.service.json
+++ b/tests/fixtures/lambda-extension-enabled.output.service.json
@@ -24,7 +24,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:86"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -47,7 +47,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:56"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/license-key-secret-disabled.output.service.json
+++ b/tests/fixtures/license-key-secret-disabled.output.service.json
@@ -25,7 +25,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:86"
       ],
       "package": {
         "exclude": [
@@ -53,7 +53,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:56"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-disabled.output.service.json
+++ b/tests/fixtures/log-disabled.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:86"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -50,7 +50,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:56"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/log-ingestion-via-extension.output.service.json
+++ b/tests/fixtures/log-ingestion-via-extension.output.service.json
@@ -28,7 +28,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:86"
       ],
       "package": {
         "exclude": [
@@ -57,7 +57,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:56"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-level.output.service.json
+++ b/tests/fixtures/log-level.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:86"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -43,6 +43,7 @@
         "NEW_RELIC_APP_NAME": "layer-nodejs12x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
+        "NEW_RELIC_LOG_ENABLED": "true",
         "NEW_RELIC_LOG_LEVEL": "error",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
@@ -52,7 +53,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:56"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -64,6 +65,7 @@
         "NEW_RELIC_APP_NAME": "layer-nodejs14x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
+        "NEW_RELIC_LOG_ENABLED": "true",
         "NEW_RELIC_LOG_LEVEL": "error",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"

--- a/tests/fixtures/provider-environment-log-level.output.service.json
+++ b/tests/fixtures/provider-environment-log-level.output.service.json
@@ -34,7 +34,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:86"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -46,8 +46,9 @@
         "NEW_RELIC_APP_NAME": "layer-nodejs12x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
+        "NEW_RELIC_LOG_ENABLED": "true",
         "NEW_RELIC_LOG_LEVEL": "error",
-           "NEW_RELIC_NO_CONFIG_FILE": "true",
+        "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       }
     },
@@ -55,7 +56,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:56"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -67,8 +68,9 @@
         "NEW_RELIC_APP_NAME": "layer-nodejs14x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
+        "NEW_RELIC_LOG_ENABLED": "true",
         "NEW_RELIC_LOG_LEVEL": "error",
-           "NEW_RELIC_NO_CONFIG_FILE": "true",
+        "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       }
     }

--- a/tests/fixtures/provider-environment.output.service.json
+++ b/tests/fixtures/provider-environment.output.service.json
@@ -33,7 +33,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:86"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -45,6 +45,7 @@
         "NEW_RELIC_APP_NAME": "layer-nodejs12x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
+        "NEW_RELIC_LOG_ENABLED": "true",
         "NEW_RELIC_LOG_LEVEL": "error",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
@@ -54,7 +55,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:56"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -66,8 +67,9 @@
         "NEW_RELIC_APP_NAME": "layer-nodejs14x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
+        "NEW_RELIC_LOG_ENABLED": "true",
         "NEW_RELIC_LOG_LEVEL": "error",
-           "NEW_RELIC_NO_CONFIG_FILE": "true",
+        "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       }
     }

--- a/tests/fixtures/provider-layer.output.service.json
+++ b/tests/fixtures/provider-layer.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:86"
     ],
     "name": "aws",
     "stage": "prod",

--- a/tests/fixtures/proxy.output.service.json
+++ b/tests/fixtures/proxy.output.service.json
@@ -24,7 +24,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:86"
       ],
       "package": {
         "exclude": [
@@ -52,7 +52,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:56"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/stage-included.output.service.json
+++ b/tests/fixtures/stage-included.output.service.json
@@ -30,7 +30,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:86"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -49,7 +49,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:56"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/trusted-account-key-excluded.output.service.json
+++ b/tests/fixtures/trusted-account-key-excluded.output.service.json
@@ -29,7 +29,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:86"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -48,7 +48,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:56"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/trusted-account-key-included.output.service.json
+++ b/tests/fixtures/trusted-account-key-included.output.service.json
@@ -30,7 +30,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:85"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:86"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -49,7 +49,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:55"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:56"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],


### PR DESCRIPTION
Agents need this in serverless mode. Closes #250

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>