### PR TITLE
Add stage to Java example

### DIFF
--- a/examples/java/serverless.yml
+++ b/examples/java/serverless.yml
@@ -17,6 +17,7 @@ provider:
   name: aws
   runtime: java11
   region: us-west-1
+  stage: dev
 
 package:
   artifact: 'target/${self:service}-${self:provider.stage}.jar'


### PR DESCRIPTION
provider.stage was missing in the Java example, which prevented deployment.

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>