### PR TITLE
Fix NR not accessible to a function with layers defined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -495,7 +495,7 @@ or make sure that you already have Serverless 3.x installed in your project.
         "provider.architecture",
         null
       ),
-      layers = [],
+      layers,
       package: pkg = {},
     } = funcDef;
 
@@ -530,12 +530,13 @@ or make sure that you already have Serverless 3.x installed in your project.
       return;
     }
 
-    if (shouldUseProviderLayers) {
+    if (shouldUseProviderLayers && !layers) {
       this.log.warning(
         `Function "${funcName}" already will be handled with provider.layers; skipping.`
       );
     } else {
-      const newRelicLayers = layers.filter(
+      const funcLayers = layers || [];
+      const newRelicLayers = funcLayers.filter(
         (layer) => typeof layer === "string" && layer.match(layerArn)
       );
 
@@ -546,12 +547,12 @@ or make sure that you already have Serverless 3.x installed in your project.
         );
       } else {
         if (this.prependLayer) {
-          layers.unshift(layerArn);
+          funcLayers.unshift(layerArn);
         } else {
-          layers.push(layerArn);
+          funcLayers.push(layerArn);
         }
 
-        funcDef.layers = layers;
+        funcDef.layers = funcLayers;
       }
     }
 

--- a/tests/fixtures/arm64.output.service.json
+++ b/tests/fixtures/arm64.output.service.json
@@ -52,7 +52,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14XARM64:47"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14XARM64:48"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/debug-log-level.output.service.json
+++ b/tests/fixtures/debug-log-level.output.service.json
@@ -54,7 +54,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:73"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/debug.output.service.json
+++ b/tests/fixtures/debug.output.service.json
@@ -53,7 +53,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:73"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -75,7 +75,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:20"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:21"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/distributed-tracing-enabled.output.service.json
+++ b/tests/fixtures/distributed-tracing-enabled.output.service.json
@@ -50,7 +50,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:73"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/eu.output.service.json
+++ b/tests/fixtures/eu.output.service.json
@@ -55,7 +55,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:73"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/function-has-layers.input.service.json
+++ b/tests/fixtures/function-has-layers.input.service.json
@@ -1,0 +1,43 @@
+{
+  "service": "newrelic-lambda-layers-nodejs-example",
+  "provider": {
+    "name": "aws",
+    "stage": "prod",
+    "region": "us-east-1",
+    "stackTags": {
+      "environment": "us-testing",
+      "owning_team": "LAMBDA",
+      "product": "aws-lambda"
+    },
+    "tags": {
+      "environment": "us-testing",
+      "owning_team": "LAMBDA",
+      "product": "aws-lambda"
+    }
+  },
+  "plugins": [
+    "serverless-newrelic-lambda-layers"
+  ],
+  "custom": {
+    "newRelic": {
+      "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
+      "apiKey": "${env:NEW_RELIC_PERSONAL_API_KEY}",
+      "logLevel": "debug"
+    }
+  },
+  "functions": {
+    "layer-nodejs12x1": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs12.x",
+      "layers": ["arn:aws:lambda:us-east-1:123456789012:layer:SomeOtherLayer:1"]
+    },
+    "layer-nodejs12x2": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs12.x"
+    }
+  }
+}

--- a/tests/fixtures/function-has-layers.output.service.json
+++ b/tests/fixtures/function-has-layers.output.service.json
@@ -1,0 +1,69 @@
+{
+  "service": "newrelic-lambda-layers-nodejs-example",
+  "provider": {
+    "layers": [
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:90"
+    ],
+    "name": "aws",
+    "stage": "prod",
+    "region": "us-east-1",
+    "stackTags": {
+      "environment": "us-testing",
+      "owning_team": "LAMBDA",
+      "product": "aws-lambda"
+    },
+    "tags": {
+      "environment": "us-testing",
+      "owning_team": "LAMBDA",
+      "product": "aws-lambda"
+    }
+  },
+  "plugins": ["serverless-newrelic-lambda-layers"],
+  "configValidationMode": "warn",
+  "custom": {
+    "newRelic": {
+      "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
+      "apiKey": "${env:NEW_RELIC_PERSONAL_API_KEY}",
+      "logLevel": "debug"
+    }
+  },
+  "disabledDeprecations": [],
+  "functions": {
+    "layer-nodejs12x1": {
+      "environment": {
+        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
+        "NEW_RELIC_APP_NAME": "layer-nodejs12x1",
+        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
+        "NEW_RELIC_NO_CONFIG_FILE": "true",
+        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
+      },
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "newrelic-lambda-wrapper.handler",
+      "package": {
+        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
+        "include": ["handler.js"]
+      },
+      "runtime": "nodejs12.x",
+      "layers": [
+        "arn:aws:lambda:us-east-1:123456789012:layer:SomeOtherLayer:1",
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:90"
+      ]
+    },
+    "layer-nodejs12x2": {
+      "environment": {
+        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
+        "NEW_RELIC_APP_NAME": "layer-nodejs12x2",
+        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
+        "NEW_RELIC_NO_CONFIG_FILE": "true",
+        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
+      },
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "newrelic-lambda-wrapper.handler",
+      "package": {
+        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
+        "include": ["handler.js"]
+      },
+      "runtime": "nodejs12.x"
+    }
+  }
+}

--- a/tests/fixtures/function-has-layers.output.service.json
+++ b/tests/fixtures/function-has-layers.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:90"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
     ],
     "name": "aws",
     "stage": "prod",
@@ -46,7 +46,7 @@
       "runtime": "nodejs12.x",
       "layers": [
         "arn:aws:lambda:us-east-1:123456789012:layer:SomeOtherLayer:1",
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:90"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
       ]
     },
     "layer-nodejs12x2": {

--- a/tests/fixtures/include.output.service.json
+++ b/tests/fixtures/include.output.service.json
@@ -43,7 +43,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers":  [
-           "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:73"
+           "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
        ],
       "package": { "exclude": [
         "./**",

--- a/tests/fixtures/lambda-extension-disabled.output.service.json
+++ b/tests/fixtures/lambda-extension-disabled.output.service.json
@@ -49,7 +49,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:73"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/lambda-extension-enabled.output.service.json
+++ b/tests/fixtures/lambda-extension-enabled.output.service.json
@@ -47,7 +47,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:73"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/license-key-secret-disabled.output.service.json
+++ b/tests/fixtures/license-key-secret-disabled.output.service.json
@@ -53,7 +53,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:73"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-disabled.output.service.json
+++ b/tests/fixtures/log-disabled.output.service.json
@@ -50,7 +50,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:73"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/log-ingestion-via-extension.output.service.json
+++ b/tests/fixtures/log-ingestion-via-extension.output.service.json
@@ -57,7 +57,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:73"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-level.output.service.json
+++ b/tests/fixtures/log-level.output.service.json
@@ -53,7 +53,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:73"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment-log-level.output.service.json
+++ b/tests/fixtures/provider-environment-log-level.output.service.json
@@ -56,7 +56,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:73"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment.output.service.json
+++ b/tests/fixtures/provider-environment.output.service.json
@@ -55,7 +55,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:73"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/proxy.output.service.json
+++ b/tests/fixtures/proxy.output.service.json
@@ -52,7 +52,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:73"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/stage-included.output.service.json
+++ b/tests/fixtures/stage-included.output.service.json
@@ -49,7 +49,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:73"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/trusted-account-key-excluded.output.service.json
+++ b/tests/fixtures/trusted-account-key-excluded.output.service.json
@@ -48,7 +48,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:73"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/trusted-account-key-included.output.service.json
+++ b/tests/fixtures/trusted-account-key-included.output.service.json
@@ -49,7 +49,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:73"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],


### PR DESCRIPTION
I have a service with several functions that were working fine with `serverless-newrelic-lambda-layers`, but then I added a new function that needed its own `layers` definition within the function:

```
functions:
  mySpecialFunction:
    layers:
      - arn:aws:lambda:us-east-1:123456789012:layer:SomeSpecialLayer:1
```
When I added this new function, it did not have access to `newrelic_lambda_wrapper`:

```
Runtime.ImportModuleError: Unable to import module 'newrelic_lambda_wrapper': No module named 'newrelic_lambda_wrapper'
```

It turns out that if `layers` is specified under a function, it will override (not merge with) any layers at the provider level.

This should fix things by adding the New Relic layer to functions that have any `layers` already defined, even if `shouldUseProviderLayers` is `true` and provider layers will be used for the other functions.

NOTE: I had to bump the layer versions used in the tests to get them to pass. I hope that's ok.
