### PR TITLE
chore: Updated version, updated husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-newrelic-lambda-layers",
-      "version": "3.3.5",
+      "version": "3.3.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/fs-extra": "^9.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [
@@ -14,12 +14,8 @@
     "test": "jest",
     "test:watch": "jest --watchAll",
     "lint": "tslint -c tslint.json 'src/**/*.ts'",
-    "generate:test:case": "yaml2json examples/nodejs/serverless.yml > tests/fixtures/example.input.service.json"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run lint"
-    }
+    "generate:test:case": "yaml2json examples/nodejs/serverless.yml > tests/fixtures/example.input.service.json",
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",
@@ -51,13 +47,13 @@
     "yamljs": "^0.3.0"
   },
   "peerDependencies": {
+    "@types/serverless": "^3.12.7",
     "fs-extra": "^10.0.1",
     "https-proxy-agent": "^5.0.0",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.7",
     "path": "^0.12.7",
     "semver": "^7.3.5",
-    "@types/serverless": "^3.12.7",
     "serverless": "^3.19.0"
   },
   "keywords": [


### PR DESCRIPTION
A just-merged dependency update resulted in an updated version of husky, which used a different config structure. This updates the project. If you encounter an error on commit, you may need to run the husky project's updater: https://github.com/typicode/husky-4-to-8

We need to bump plugin version manually for release. 

Signed-off-by: mrickard <maurice@mauricerickard.com>