### PR TITLE
Support nodejs18.x as the lambda layers are not build

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ This plugin currently supports the following AWS runtimes:
 - nodejs12.x
 - nodejs14.x
 - nodejs16.x
+- nodejs18.x
 - python3.6
 - python3.7
 - python3.8

--- a/src/index.ts
+++ b/src/index.ts
@@ -736,7 +736,11 @@ or make sure that you already have Serverless 3.x installed in your project.
   }
 
   private getHandlerWrapper(runtime: string, handler: string) {
-    if (["nodejs12.x", "nodejs14.x", "nodejs16.x", "nodejs18.x"].indexOf(runtime) !== -1) {
+    if (
+      ["nodejs12.x", "nodejs14.x", "nodejs16.x", "nodejs18.x"].indexOf(
+        runtime
+      ) !== -1
+    ) {
       return "newrelic-lambda-wrapper.handler";
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ const wrappableRuntimeList = [
   "nodejs12.x",
   "nodejs14.x",
   "nodejs16.x",
+  "nodejs18.x",
   "python3.6",
   "python3.7",
   "python3.8",
@@ -735,7 +736,7 @@ or make sure that you already have Serverless 3.x installed in your project.
   }
 
   private getHandlerWrapper(runtime: string, handler: string) {
-    if (["nodejs12.x", "nodejs14.x", "nodejs16.x"].indexOf(runtime) !== -1) {
+    if (["nodejs12.x", "nodejs14.x", "nodejs16.x", "nodejs18.x"].indexOf(runtime) !== -1) {
       return "newrelic-lambda-wrapper.handler";
     }
 

--- a/tests/fixtures/arm64-unsupported.input.service.json
+++ b/tests/fixtures/arm64-unsupported.input.service.json
@@ -43,23 +43,6 @@
         ]
       },
       "runtime": "nodejs12.x"
-    },
-    "layer-nodejs14x": {
-      "events": [
-        {
-          "schedule": "rate(5 minutes)"
-        }
-      ],
-      "handler": "handler.handler",
-      "package": {
-        "exclude": [
-          "./**"
-        ],
-        "include": [
-          "handler.js"
-        ]
-      },
-      "runtime": "nodejs14.x"
     }
   }
 }

--- a/tests/fixtures/arm64-unsupported.output.service.json
+++ b/tests/fixtures/arm64-unsupported.output.service.json
@@ -25,23 +25,6 @@
         ]
       },
       "runtime": "nodejs12.x"
-    },
-    "layer-nodejs14x": {
-      "events": [
-        {
-          "schedule": "rate(5 minutes)"
-        }
-      ],
-      "handler": "handler.handler",
-      "package": {
-        "exclude": [
-          "./**"
-        ],
-        "include": [
-          "handler.js"
-        ]
-      },
-      "runtime": "nodejs14.x"
     }
   },
   "plugins": [

--- a/tests/fixtures/arm64.output.service.json
+++ b/tests/fixtures/arm64.output.service.json
@@ -52,7 +52,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14XARM64:48"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14XARM64:54"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/debug-log-level.output.service.json
+++ b/tests/fixtures/debug-log-level.output.service.json
@@ -54,7 +54,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:80"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/debug.output.service.json
+++ b/tests/fixtures/debug.output.service.json
@@ -75,7 +75,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:21"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:27"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/debug.output.service.json
+++ b/tests/fixtures/debug.output.service.json
@@ -53,7 +53,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:80"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/distributed-tracing-enabled.output.service.json
+++ b/tests/fixtures/distributed-tracing-enabled.output.service.json
@@ -50,7 +50,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:80"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/eu.output.service.json
+++ b/tests/fixtures/eu.output.service.json
@@ -55,7 +55,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:80"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/include.output.service.json
+++ b/tests/fixtures/include.output.service.json
@@ -43,7 +43,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers":  [
-           "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
+           "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:80"
        ],
       "package": { "exclude": [
         "./**",

--- a/tests/fixtures/lambda-extension-disabled.output.service.json
+++ b/tests/fixtures/lambda-extension-disabled.output.service.json
@@ -49,7 +49,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:80"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/lambda-extension-enabled.output.service.json
+++ b/tests/fixtures/lambda-extension-enabled.output.service.json
@@ -47,7 +47,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:80"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/license-key-secret-disabled.output.service.json
+++ b/tests/fixtures/license-key-secret-disabled.output.service.json
@@ -53,7 +53,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:80"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-disabled.output.service.json
+++ b/tests/fixtures/log-disabled.output.service.json
@@ -50,7 +50,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:80"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/log-ingestion-via-extension.output.service.json
+++ b/tests/fixtures/log-ingestion-via-extension.output.service.json
@@ -57,7 +57,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:80"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-level.output.service.json
+++ b/tests/fixtures/log-level.output.service.json
@@ -53,7 +53,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:80"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment-log-level.output.service.json
+++ b/tests/fixtures/provider-environment-log-level.output.service.json
@@ -56,7 +56,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:80"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment.output.service.json
+++ b/tests/fixtures/provider-environment.output.service.json
@@ -55,7 +55,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:80"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/proxy.output.service.json
+++ b/tests/fixtures/proxy.output.service.json
@@ -52,7 +52,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:80"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/stage-included.output.service.json
+++ b/tests/fixtures/stage-included.output.service.json
@@ -49,7 +49,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:80"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/trusted-account-key-excluded.output.service.json
+++ b/tests/fixtures/trusted-account-key-excluded.output.service.json
@@ -48,7 +48,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:80"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/trusted-account-key-included.output.service.json
+++ b/tests/fixtures/trusted-account-key-included.output.service.json
@@ -49,7 +49,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:74"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:80"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],


### PR DESCRIPTION
* adjusted tests as new version of layers exist
* remove arm64 unsupported test for nodejs14.x in region ap as it has now support of it