### PR TITLE
chore: Updated version for release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "3.3.7",
+  "version": "3.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-newrelic-lambda-layers",
-      "version": "3.3.7",
+      "version": "3.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/fs-extra": "^9.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "3.3.7",
+  "version": "3.4.0",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
Version 3.4.0 now supports Node 18.

Signed-off-by: mrickard <maurice@mauricerickard.com>