### PR TITLE
chore(package): remove fs-extra

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
       },
       "peerDependencies": {
         "@types/serverless": "^3.12.7",
-        "fs-extra": "^10.0.1",
         "https-proxy-agent": "^5.0.0",
         "lodash": "^4.17.21",
         "node-fetch": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "peerDependencies": {
     "@types/serverless": "^3.12.7",
-    "fs-extra": "^10.0.1",
     "https-proxy-agent": "^5.0.0",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.7",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,7 +37,8 @@ export const waitForStatus = async (
 
 export const fetchPolicy = async (templatePolicy: string) => {
   const policy = await fsPromises.readFile(
-    path.resolve(__dirname, "..", "templates", templatePolicy)
+    path.resolve(__dirname, "..", "templates", templatePolicy),
+    { encoding: "utf8" }
   );
   return policy;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs-extra";
+import { promises as fsPromises } from "fs";
 import * as _ from "lodash";
 import * as path from "path";
 
@@ -36,9 +36,8 @@ export const waitForStatus = async (
 };
 
 export const fetchPolicy = async (templatePolicy: string) => {
-  const policy = await fs.readFile(
-    path.resolve(__dirname, "..", "templates", templatePolicy),
-    "utf-8"
+  const policy = await fsPromises.readFile(
+    path.resolve(__dirname, "..", "templates", templatePolicy)
   );
   return policy;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { promises as fsPromises } from "fs";
+import { readFile } from "fs/promises";
 import * as _ from "lodash";
 import * as path from "path";
 
@@ -36,7 +36,7 @@ export const waitForStatus = async (
 };
 
 export const fetchPolicy = async (templatePolicy: string) => {
-  const policy = await fsPromises.readFile(
+  const policy = await readFile(
     path.resolve(__dirname, "..", "templates", templatePolicy),
     { encoding: "utf8" }
   );

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,5 @@
 {
     "extends": ["tslint:latest", "tslint-config-prettier"],
     "rulesDirectory": ["tslint-plugin-prettier"],
-    "rules": {"prettier": true}
+    "rules": {"prettier": true, "no-submodule-imports": false}
 }


### PR DESCRIPTION
This package is used for one function that can easily be replaced with a core library function.

Closes #348 