### PR TITLE
chore: Updated test fixtures to mostly Node 16 and 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [

--- a/tests/fixtures/arm64-unsupported.input.service.json
+++ b/tests/fixtures/arm64-unsupported.input.service.json
@@ -3,7 +3,7 @@
   "provider": {
     "name": "aws",
     "stage": "prod",
-    "region": "ap-northeast-2",
+    "region": "ap-south-2",
     "architecture": "arm64",
     "stackTags": {
       "environment": "us-testing",
@@ -27,7 +27,7 @@
     }
   },
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [
         {
           "schedule": "rate(5 minutes)"
@@ -42,7 +42,24 @@
           "handler.js"
         ]
       },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
+    },
+    "layer-nodejs18x": {
+      "events": [
+        {
+          "schedule": "rate(5 minutes)"
+        }
+      ],
+      "handler": "handler.handler",
+      "package": {
+        "exclude": [
+          "./**"
+        ],
+        "include": [
+          "handler.js"
+        ]
+      },
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/arm64-unsupported.output.service.json
+++ b/tests/fixtures/arm64-unsupported.output.service.json
@@ -9,7 +9,7 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [
         {
           "schedule": "rate(5 minutes)"
@@ -24,7 +24,24 @@
           "handler.js"
         ]
       },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
+    },
+    "layer-nodejs18x": {
+      "events": [
+        {
+          "schedule": "rate(5 minutes)"
+        }
+      ],
+      "handler": "handler.handler",
+      "package": {
+        "exclude": [
+          "./**"
+        ],
+        "include": [
+          "handler.js"
+        ]
+      },
+      "runtime": "nodejs18.x"
     }
   },
   "plugins": [
@@ -33,7 +50,7 @@
   "provider": {
     "architecture": "arm64",
     "name": "aws",
-    "region": "ap-northeast-2",
+    "region": "ap-south-2",
     "stackTags": {
       "environment": "us-testing",
       "owning_team": "LAMBDA",

--- a/tests/fixtures/arm64.input.service.json
+++ b/tests/fixtures/arm64.input.service.json
@@ -27,7 +27,7 @@
     }
   },
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [
         {
           "schedule": "rate(5 minutes)"
@@ -42,9 +42,9 @@
           "handler.js"
         ]
       },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [
         {
           "schedule": "rate(5 minutes)"
@@ -59,7 +59,7 @@
           "handler.js"
         ]
       },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/arm64.output.service.json
+++ b/tests/fixtures/arm64.output.service.json
@@ -24,7 +24,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16XARM64:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16XARM64:60"
       ],
       "package": {
         "exclude": [
@@ -52,7 +52,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18XARM64:33"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18XARM64:35"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/arm64.output.service.json
+++ b/tests/fixtures/arm64.output.service.json
@@ -9,10 +9,10 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs16x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
@@ -24,7 +24,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12XARM64:38"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16XARM64:58"
       ],
       "package": {
         "exclude": [
@@ -35,12 +35,12 @@
           "handler.js"
         ]
       },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs14x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
@@ -52,7 +52,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14XARM64:78"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18XARM64:33"
       ],
       "package": {
         "exclude": [
@@ -63,7 +63,7 @@
           "handler.js"
         ]
       },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   },
   "plugins": [

--- a/tests/fixtures/debug-log-level.input.service.json
+++ b/tests/fixtures/debug-log-level.input.service.json
@@ -28,17 +28,17 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/debug-log-level.output.service.json
+++ b/tests/fixtures/debug-log-level.output.service.json
@@ -32,7 +32,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -54,7 +54,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/debug-log-level.output.service.json
+++ b/tests/fixtures/debug-log-level.output.service.json
@@ -28,20 +28,20 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs12.x",
+      "runtime": "nodejs16.x",
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs16x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
         "NEW_RELIC_LOG_ENABLED": "true",
@@ -50,20 +50,20 @@
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       }
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:104"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs14.x",
+      "runtime": "nodejs18.x",
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs14x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
         "NEW_RELIC_LOG_ENABLED": "true",

--- a/tests/fixtures/debug.input.service.json
+++ b/tests/fixtures/debug.input.service.json
@@ -27,12 +27,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
-    },
     "layer-nodejs14x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
@@ -44,6 +38,12 @@
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
       "runtime": "nodejs16.x"
+    },
+    "layer-nodejs18x": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/debug.output.service.json
+++ b/tests/fixtures/debug.output.service.json
@@ -27,33 +27,11 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs12.x",
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_LOG": "stdout",
-        "NEW_RELIC_LOG_ENABLED": "true",
-        "NEW_RELIC_LOG_LEVEL": "debug",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
-    },
     "layer-nodejs14x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:104"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:111"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -75,7 +53,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:51"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -85,6 +63,28 @@
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
         "NEW_RELIC_APP_NAME": "layer-nodejs16x",
+        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
+        "NEW_RELIC_LOG": "stdout",
+        "NEW_RELIC_LOG_ENABLED": "true",
+        "NEW_RELIC_LOG_LEVEL": "debug",
+        "NEW_RELIC_NO_CONFIG_FILE": "true",
+        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
+      }
+    },
+    "layer-nodejs18x": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "newrelic-lambda-wrapper.handler",
+      "layers": [
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+      ],
+      "package": {
+        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
+        "include": ["handler.js"]
+      },
+      "runtime": "nodejs18.x",
+      "environment": {
+        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
         "NEW_RELIC_LOG_ENABLED": "true",

--- a/tests/fixtures/debug.output.service.json
+++ b/tests/fixtures/debug.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:111"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:113"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -53,7 +53,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -75,7 +75,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/distributed-tracing-enabled.input.service.json
+++ b/tests/fixtures/distributed-tracing-enabled.input.service.json
@@ -25,17 +25,17 @@
     }
   },
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/distributed-tracing-enabled.output.service.json
+++ b/tests/fixtures/distributed-tracing-enabled.output.service.json
@@ -10,10 +10,10 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs16x",
         "NEW_RELIC_DISTRIBUTED_TRACING_ENABLED": "true",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
@@ -26,18 +26,18 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs14x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x",
         "NEW_RELIC_DISTRIBUTED_TRACING_ENABLED": "true",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
@@ -50,13 +50,13 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:104"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   },
   "plugins": ["serverless-newrelic-lambda-layers"],

--- a/tests/fixtures/distributed-tracing-enabled.output.service.json
+++ b/tests/fixtures/distributed-tracing-enabled.output.service.json
@@ -26,7 +26,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -50,7 +50,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/eu.input.service.json
+++ b/tests/fixtures/eu.input.service.json
@@ -28,17 +28,17 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/eu.output.service.json
+++ b/tests/fixtures/eu.output.service.json
@@ -29,7 +29,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -55,7 +55,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/eu.output.service.json
+++ b/tests/fixtures/eu.output.service.json
@@ -11,10 +11,10 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs16x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
         "NEW_RELIC_LOG_ENABLED": "true",
@@ -29,18 +29,18 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs14x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
         "NEW_RELIC_LOG_ENABLED": "true",
@@ -55,13 +55,13 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:104"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   },
   "plugins": ["serverless-newrelic-lambda-layers"],

--- a/tests/fixtures/function-has-layers.input.service.json
+++ b/tests/fixtures/function-has-layers.input.service.json
@@ -26,18 +26,18 @@
     }
   },
   "functions": {
-    "layer-nodejs12x1": {
+    "layer-nodejs18x1": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x",
+      "runtime": "nodejs18.x",
       "layers": ["arn:aws:lambda:us-east-1:123456789012:layer:SomeOtherLayer:1"]
     },
-    "layer-nodejs12x2": {
+    "layer-nodejs18x2": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/function-has-layers.output.service.json
+++ b/tests/fixtures/function-has-layers.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
     ],
     "name": "aws",
     "stage": "prod",
@@ -46,7 +46,7 @@
       "runtime": "nodejs18.x",
       "layers": [
         "arn:aws:lambda:us-east-1:123456789012:layer:SomeOtherLayer:1",
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
       ]
     },
     "layer-nodejs18x2": {

--- a/tests/fixtures/function-has-layers.output.service.json
+++ b/tests/fixtures/function-has-layers.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
     ],
     "name": "aws",
     "stage": "prod",
@@ -29,10 +29,10 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x1": {
+    "layer-nodejs18x1": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x1",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x1",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
@@ -43,16 +43,16 @@
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs12.x",
+      "runtime": "nodejs18.x",
       "layers": [
         "arn:aws:lambda:us-east-1:123456789012:layer:SomeOtherLayer:1",
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
       ]
     },
-    "layer-nodejs12x2": {
+    "layer-nodejs18x2": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x2",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x2",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
@@ -63,7 +63,7 @@
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/include-exclude.input.service.json
+++ b/tests/fixtures/include-exclude.input.service.json
@@ -20,23 +20,23 @@
   "custom": {
     "newRelic": {
       "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
-      "include": ["layer-nodejs12x"],
-      "exclude": ["layer-nodejs14x"]
+      "include": ["layer-nodejs16x"],
+      "exclude": ["layer-nodejs18x"]
     }
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/include-exclude.output.service.json
+++ b/tests/fixtures/include-exclude.output.service.json
@@ -20,23 +20,23 @@
   "custom": {
     "newRelic": {
       "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
-      "include": ["layer-nodejs12x"],
-      "exclude": ["layer-nodejs14x"]
+      "include": ["layer-nodejs16x"],
+      "exclude": ["layer-nodejs18x"]
     }
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/include.input.service.json
+++ b/tests/fixtures/include.input.service.json
@@ -21,22 +21,22 @@
     "newRelic": {
       "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
       "apiKey": "${env:NEW_RELIC_PERSONAL_API_KEY}",
-      "include": ["layer-nodejs14x"]
+      "include": ["layer-nodejs18x"]
     }
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/include.output.service.json
+++ b/tests/fixtures/include.output.service.json
@@ -21,21 +21,21 @@
     "newRelic": {
       "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
       "apiKey": "${env:NEW_RELIC_PERSONAL_API_KEY}",
-      "include": ["layer-nodejs14x"]
+      "include": ["layer-nodejs18x"]
     }
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
        "environment": {
          "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-         "NEW_RELIC_APP_NAME": "layer-nodejs14x",
+         "NEW_RELIC_APP_NAME": "layer-nodejs18x",
          "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
          "NEW_RELIC_NO_CONFIG_FILE": "true",
          "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
@@ -43,13 +43,13 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers":  [
-           "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:104"
+           "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
        ],
       "package": { "exclude": [
         "./**",
         "!newrelic-wrapper-helper.js"
       ], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/include.output.service.json
+++ b/tests/fixtures/include.output.service.json
@@ -43,7 +43,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers":  [
-           "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+           "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
        ],
       "package": { "exclude": [
         "./**",

--- a/tests/fixtures/includes-all-provider-layer.input.service.json
+++ b/tests/fixtures/includes-all-provider-layer.input.service.json
@@ -21,22 +21,22 @@
     "newRelic": {
       "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
       "apiKey": "${env:NEW_RELIC_PERSONAL_API_KEY}",
-      "include": ["layer-nodejs12x1", "layer-nodejs12x2"]
+      "include": ["layer-nodejs18x1", "layer-nodejs18x2"]
     }
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x1": {
+    "layer-nodejs18x1": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs18.x"
     },
-    "layer-nodejs12x2": {
+    "layer-nodejs18x2": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/includes-all-provider-layer.output.service.json
+++ b/tests/fixtures/includes-all-provider-layer.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
     ],
     "name": "aws",
     "stage": "prod",

--- a/tests/fixtures/includes-all-provider-layer.output.service.json
+++ b/tests/fixtures/includes-all-provider-layer.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
     ],
     "name": "aws",
     "stage": "prod",
@@ -24,15 +24,15 @@
     "newRelic": {
       "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
       "apiKey": "${env:NEW_RELIC_PERSONAL_API_KEY}",
-      "include": ["layer-nodejs12x1", "layer-nodejs12x2"]
+      "include": ["layer-nodejs18x1", "layer-nodejs18x2"]
     }
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x1": {
+    "layer-nodejs18x1": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x1",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x1",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
@@ -43,12 +43,12 @@
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs18.x"
     },
-    "layer-nodejs12x2": {
+    "layer-nodejs18x2": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x2",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x2",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
@@ -59,7 +59,7 @@
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/lambda-extension-disabled.input.service.json
+++ b/tests/fixtures/lambda-extension-disabled.input.service.json
@@ -24,17 +24,17 @@
     }
   },
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/lambda-extension-disabled.output.service.json
+++ b/tests/fixtures/lambda-extension-disabled.output.service.json
@@ -9,10 +9,10 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs16x",
         "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "false",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
@@ -25,18 +25,18 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs14x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x",
         "NEW_RELIC_LAMBDA_EXTENSION_ENABLED": "false",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
@@ -49,13 +49,13 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:104"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   },
   "plugins": ["serverless-newrelic-lambda-layers"],

--- a/tests/fixtures/lambda-extension-disabled.output.service.json
+++ b/tests/fixtures/lambda-extension-disabled.output.service.json
@@ -25,7 +25,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -49,7 +49,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/lambda-extension-enabled.input.service.json
+++ b/tests/fixtures/lambda-extension-enabled.input.service.json
@@ -24,17 +24,17 @@
     }
   },
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/lambda-extension-enabled.output.service.json
+++ b/tests/fixtures/lambda-extension-enabled.output.service.json
@@ -9,10 +9,10 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs16x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
@@ -24,18 +24,18 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs14x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
@@ -47,13 +47,13 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:104"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   },
   "plugins": ["serverless-newrelic-lambda-layers"],

--- a/tests/fixtures/lambda-extension-enabled.output.service.json
+++ b/tests/fixtures/lambda-extension-enabled.output.service.json
@@ -24,7 +24,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -47,7 +47,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/license-key-null.input.service.json
+++ b/tests/fixtures/license-key-null.input.service.json
@@ -26,7 +26,7 @@
     }
   },
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [
         {
           "schedule": "rate(5 minutes)"
@@ -41,9 +41,9 @@
           "handler.js"
         ]
       },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [
         {
           "schedule": "rate(5 minutes)"
@@ -58,7 +58,7 @@
           "handler.js"
         ]
       },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/license-key-null.output.service.json
+++ b/tests/fixtures/license-key-null.output.service.json
@@ -9,7 +9,7 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [
         {
           "schedule": "rate(5 minutes)"
@@ -24,9 +24,9 @@
           "handler.js"
         ]
       },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [
         {
           "schedule": "rate(5 minutes)"
@@ -41,7 +41,7 @@
           "handler.js"
         ]
       },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   },
   "plugins": [

--- a/tests/fixtures/license-key-secret-disabled.input.service.json
+++ b/tests/fixtures/license-key-secret-disabled.input.service.json
@@ -25,17 +25,17 @@
     }
   },
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/license-key-secret-disabled.output.service.json
+++ b/tests/fixtures/license-key-secret-disabled.output.service.json
@@ -25,7 +25,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
       ],
       "package": {
         "exclude": [
@@ -53,7 +53,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/license-key-secret-disabled.output.service.json
+++ b/tests/fixtures/license-key-secret-disabled.output.service.json
@@ -10,10 +10,10 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs16x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
@@ -25,7 +25,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
       ],
       "package": {
         "exclude": [
@@ -36,12 +36,12 @@
           "handler.js"
         ]
       },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs14x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
@@ -53,7 +53,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:104"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
       ],
       "package": {
         "exclude": [
@@ -64,7 +64,7 @@
           "handler.js"
         ]
       },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   },
   "plugins": ["serverless-newrelic-lambda-layers"],

--- a/tests/fixtures/log-disabled.input.service.json
+++ b/tests/fixtures/log-disabled.input.service.json
@@ -27,17 +27,17 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/log-disabled.output.service.json
+++ b/tests/fixtures/log-disabled.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -50,7 +50,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/log-disabled.output.service.json
+++ b/tests/fixtures/log-disabled.output.service.json
@@ -27,39 +27,39 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs12.x",
+      "runtime": "nodejs16.x",
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs16x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       }
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:104"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs14.x",
+      "runtime": "nodejs18.x",
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs14x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"

--- a/tests/fixtures/log-ingestion-via-extension.input.service.json
+++ b/tests/fixtures/log-ingestion-via-extension.input.service.json
@@ -27,17 +27,17 @@
     }
   },
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/log-ingestion-via-extension.output.service.json
+++ b/tests/fixtures/log-ingestion-via-extension.output.service.json
@@ -12,10 +12,10 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs16x",
         "NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS": "true",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
@@ -28,7 +28,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
       ],
       "package": {
         "exclude": [
@@ -39,12 +39,12 @@
           "handler.js"
         ]
       },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs14x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x",
         "NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS": "true",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
@@ -57,7 +57,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:104"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
       ],
       "package": {
         "exclude": [
@@ -68,7 +68,7 @@
           "handler.js"
         ]
       },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   },
   "plugins": ["serverless-newrelic-lambda-layers"],

--- a/tests/fixtures/log-ingestion-via-extension.output.service.json
+++ b/tests/fixtures/log-ingestion-via-extension.output.service.json
@@ -28,7 +28,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
       ],
       "package": {
         "exclude": [
@@ -57,7 +57,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-level.input.service.json
+++ b/tests/fixtures/log-level.input.service.json
@@ -27,17 +27,17 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/log-level.output.service.json
+++ b/tests/fixtures/log-level.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -53,7 +53,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/log-level.output.service.json
+++ b/tests/fixtures/log-level.output.service.json
@@ -27,20 +27,20 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs12.x",
+      "runtime": "nodejs16.x",
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs16x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
         "NEW_RELIC_LOG_ENABLED": "true",
@@ -49,20 +49,20 @@
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       }
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:104"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs14.x",
+      "runtime": "nodejs18.x",
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs14x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
         "NEW_RELIC_LOG_ENABLED": "true",

--- a/tests/fixtures/provider-environment-log-level.input.service.json
+++ b/tests/fixtures/provider-environment-log-level.input.service.json
@@ -30,17 +30,17 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/provider-environment-log-level.output.service.json
+++ b/tests/fixtures/provider-environment-log-level.output.service.json
@@ -30,20 +30,20 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs12.x",
+      "runtime": "nodejs16.x",
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs16x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
         "NEW_RELIC_LOG_ENABLED": "true",
@@ -52,20 +52,20 @@
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       }
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:104"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs14.x",
+      "runtime": "nodejs18.x",
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs14x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
         "NEW_RELIC_LOG_ENABLED": "true",

--- a/tests/fixtures/provider-environment-log-level.output.service.json
+++ b/tests/fixtures/provider-environment-log-level.output.service.json
@@ -34,7 +34,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -56,7 +56,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment.input.service.json
+++ b/tests/fixtures/provider-environment.input.service.json
@@ -29,17 +29,17 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/provider-environment.output.service.json
+++ b/tests/fixtures/provider-environment.output.service.json
@@ -29,20 +29,20 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs12.x",
+      "runtime": "nodejs16.x",
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs16x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
         "NEW_RELIC_LOG_ENABLED": "true",
@@ -51,20 +51,20 @@
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       }
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:104"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs14.x",
+      "runtime": "nodejs18.x",
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs14x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_LOG": "stdout",
         "NEW_RELIC_LOG_ENABLED": "true",

--- a/tests/fixtures/provider-environment.output.service.json
+++ b/tests/fixtures/provider-environment.output.service.json
@@ -33,7 +33,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -55,7 +55,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-layer.input.service.json
+++ b/tests/fixtures/provider-layer.input.service.json
@@ -25,17 +25,17 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x1": {
+    "layer-nodejs18x1": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs18.x"
     },
-    "layer-nodejs12x2": {
+    "layer-nodejs18x2": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/provider-layer.output.service.json
+++ b/tests/fixtures/provider-layer.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
     ],
     "name": "aws",
     "stage": "prod",
@@ -28,10 +28,10 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x1": {
+    "layer-nodejs18x1": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x1",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x1",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
@@ -42,12 +42,12 @@
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs18.x"
     },
-    "layer-nodejs12x2": {
+    "layer-nodejs18x2": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x2",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x2",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
@@ -58,7 +58,7 @@
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/provider-layer.output.service.json
+++ b/tests/fixtures/provider-layer.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
     ],
     "name": "aws",
     "stage": "prod",

--- a/tests/fixtures/proxy.input.service.json
+++ b/tests/fixtures/proxy.input.service.json
@@ -24,17 +24,17 @@
     }
   },
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/proxy.output.service.json
+++ b/tests/fixtures/proxy.output.service.json
@@ -24,7 +24,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
       ],
       "package": {
         "exclude": [
@@ -52,7 +52,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/proxy.output.service.json
+++ b/tests/fixtures/proxy.output.service.json
@@ -9,10 +9,10 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs16x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
@@ -24,7 +24,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
       ],
       "package": {
         "exclude": [
@@ -35,12 +35,12 @@
           "handler.js"
         ]
       },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs14x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
@@ -52,7 +52,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:104"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
       ],
       "package": {
         "exclude": [
@@ -63,7 +63,7 @@
           "handler.js"
         ]
       },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   },
   "plugins": ["serverless-newrelic-lambda-layers"],

--- a/tests/fixtures/stage-excluded.input.service.json
+++ b/tests/fixtures/stage-excluded.input.service.json
@@ -26,17 +26,17 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/stage-excluded.output.service.json
+++ b/tests/fixtures/stage-excluded.output.service.json
@@ -26,17 +26,17 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/stage-included.input.service.json
+++ b/tests/fixtures/stage-included.input.service.json
@@ -26,17 +26,17 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/stage-included.output.service.json
+++ b/tests/fixtures/stage-included.output.service.json
@@ -26,39 +26,39 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs12.x",
+      "runtime": "nodejs16.x",
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs16x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       }
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:104"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs14.x",
+      "runtime": "nodejs18.x",
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs14x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"

--- a/tests/fixtures/stage-included.output.service.json
+++ b/tests/fixtures/stage-included.output.service.json
@@ -30,7 +30,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -49,7 +49,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/trusted-account-key-excluded.input.service.json
+++ b/tests/fixtures/trusted-account-key-excluded.input.service.json
@@ -25,17 +25,17 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/trusted-account-key-excluded.output.service.json
+++ b/tests/fixtures/trusted-account-key-excluded.output.service.json
@@ -25,39 +25,39 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs12.x",
+      "runtime": "nodejs16.x",
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs16x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
       }
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:104"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs14.x",
+      "runtime": "nodejs18.x",
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs14x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"

--- a/tests/fixtures/trusted-account-key-excluded.output.service.json
+++ b/tests/fixtures/trusted-account-key-excluded.output.service.json
@@ -29,7 +29,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -48,7 +48,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/trusted-account-key-included.input.service.json
+++ b/tests/fixtures/trusted-account-key-included.input.service.json
@@ -26,17 +26,17 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs12.x"
+      "runtime": "nodejs16.x"
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",
       "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
+      "runtime": "nodejs18.x"
     }
   }
 }

--- a/tests/fixtures/trusted-account-key-included.output.service.json
+++ b/tests/fixtures/trusted-account-key-included.output.service.json
@@ -26,39 +26,39 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs12x": {
+    "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS12X:93"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs12.x",
+      "runtime": "nodejs16.x",
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs12x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs16x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_TRUSTED_ACCOUNT_KEY}"
       }
     },
-    "layer-nodejs14x": {
+    "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:104"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
       },
-      "runtime": "nodejs14.x",
+      "runtime": "nodejs18.x",
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs14x",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_TRUSTED_ACCOUNT_KEY}"

--- a/tests/fixtures/trusted-account-key-included.output.service.json
+++ b/tests/fixtures/trusted-account-key-included.output.service.json
@@ -30,7 +30,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:58"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -49,7 +49,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:33"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],


### PR DESCRIPTION
Updated test fixtures to drop Node 12, reduce Node 14, and focus on 16 and 18. Also updated no-ARM64 test snapshot. 

Closes #360 
Closes NR-141282