### PR TITLE
Update supported runtimes list for Python and Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,10 +355,11 @@ This plugin currently supports the following AWS runtimes:
 - nodejs14.x
 - nodejs16.x
 - nodejs18.x
-- python3.6
 - python3.7
 - python3.8
 - python3.9
+- python3.10
+- python3.11
 - java11
 - java8.al2
 

--- a/README.md
+++ b/README.md
@@ -351,7 +351,6 @@ custom:
 
 This plugin currently supports the following AWS runtimes:
 
-- nodejs12.x
 - nodejs14.x
 - nodejs16.x
 - nodejs18.x

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "3.4.3",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "3.5.1",
+  "version": "4.0.0",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,11 +31,11 @@ const wrappableRuntimeList = [
   "nodejs14.x",
   "nodejs16.x",
   "nodejs18.x",
-  "python3.6",
   "python3.7",
   "python3.8",
   "python3.9",
   "python3.10",
+  "python3.11",
   "java11",
   "java8.al2",
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,6 @@ const logShim = {
 };
 
 const wrappableRuntimeList = [
-  "nodejs12.x",
   "nodejs14.x",
   "nodejs16.x",
   "nodejs18.x",

--- a/tests/fixtures/arm64.output.service.json
+++ b/tests/fixtures/arm64.output.service.json
@@ -24,7 +24,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16XARM64:60"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16XARM64:65"
       ],
       "package": {
         "exclude": [
@@ -52,7 +52,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18XARM64:35"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18XARM64:40"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/debug-log-level.output.service.json
+++ b/tests/fixtures/debug-log-level.output.service.json
@@ -32,7 +32,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -54,7 +54,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/debug.output.service.json
+++ b/tests/fixtures/debug.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:113"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:118"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -53,7 +53,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -75,7 +75,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/distributed-tracing-enabled.output.service.json
+++ b/tests/fixtures/distributed-tracing-enabled.output.service.json
@@ -26,7 +26,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -50,7 +50,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/eu.output.service.json
+++ b/tests/fixtures/eu.output.service.json
@@ -29,7 +29,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -55,7 +55,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/function-has-layers.output.service.json
+++ b/tests/fixtures/function-has-layers.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
     ],
     "name": "aws",
     "stage": "prod",
@@ -46,7 +46,7 @@
       "runtime": "nodejs18.x",
       "layers": [
         "arn:aws:lambda:us-east-1:123456789012:layer:SomeOtherLayer:1",
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
       ]
     },
     "layer-nodejs18x2": {

--- a/tests/fixtures/include.output.service.json
+++ b/tests/fixtures/include.output.service.json
@@ -43,7 +43,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers":  [
-           "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+           "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
        ],
       "package": { "exclude": [
         "./**",

--- a/tests/fixtures/includes-all-provider-layer.output.service.json
+++ b/tests/fixtures/includes-all-provider-layer.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
     ],
     "name": "aws",
     "stage": "prod",

--- a/tests/fixtures/lambda-extension-disabled.output.service.json
+++ b/tests/fixtures/lambda-extension-disabled.output.service.json
@@ -25,7 +25,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -49,7 +49,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/lambda-extension-enabled.output.service.json
+++ b/tests/fixtures/lambda-extension-enabled.output.service.json
@@ -24,7 +24,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -47,7 +47,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/license-key-secret-disabled.output.service.json
+++ b/tests/fixtures/license-key-secret-disabled.output.service.json
@@ -25,7 +25,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
       ],
       "package": {
         "exclude": [
@@ -53,7 +53,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-disabled.output.service.json
+++ b/tests/fixtures/log-disabled.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -50,7 +50,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/log-ingestion-via-extension.output.service.json
+++ b/tests/fixtures/log-ingestion-via-extension.output.service.json
@@ -28,7 +28,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
       ],
       "package": {
         "exclude": [
@@ -57,7 +57,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-level.output.service.json
+++ b/tests/fixtures/log-level.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -53,7 +53,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment-log-level.output.service.json
+++ b/tests/fixtures/provider-environment-log-level.output.service.json
@@ -34,7 +34,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -56,7 +56,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment.output.service.json
+++ b/tests/fixtures/provider-environment.output.service.json
@@ -33,7 +33,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -55,7 +55,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-layer.output.service.json
+++ b/tests/fixtures/provider-layer.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
     ],
     "name": "aws",
     "stage": "prod",

--- a/tests/fixtures/proxy.output.service.json
+++ b/tests/fixtures/proxy.output.service.json
@@ -24,7 +24,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
       ],
       "package": {
         "exclude": [
@@ -52,7 +52,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/stage-included.output.service.json
+++ b/tests/fixtures/stage-included.output.service.json
@@ -30,7 +30,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -49,7 +49,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/trusted-account-key-excluded.output.service.json
+++ b/tests/fixtures/trusted-account-key-excluded.output.service.json
@@ -29,7 +29,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -48,7 +48,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/trusted-account-key-included.output.service.json
+++ b/tests/fixtures/trusted-account-key-included.output.service.json
@@ -30,7 +30,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:60"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -49,7 +49,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:35"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],


### PR DESCRIPTION
This PR updates the supported runtimes list for Python and Node.
Changes:
- Drop Python 3.6 and Node 12
- Add Python 3.10 and Python 3.11

Related issue: #373 