### PR TITLE
Handle null account values returned from NR API.

### DIFF
--- a/src/integration.ts
+++ b/src/integration.ts
@@ -56,6 +56,7 @@ export default class Integration {
 
     const match = linkedAccounts.filter((account) => {
       return (
+        account &&
         account.externalId === externalId &&
         account.nrAccountId === parseInt(accountId, 10)
       );


### PR DESCRIPTION
This PR updates to ensure the `account` is not a null value. Otherwise a type error is thrown on ln 59.