### PR TITLE
fix: Updated integration to allow for paginated ListPolicies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 defaults: &defaults
   docker:
-    - image: circleci/node:16
+    - image: cimg/node:18.17
 
 jobs:
   install:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [
@@ -14,6 +14,7 @@
     "test": "jest",
     "test:watch": "jest --watchAll",
     "lint": "tslint -c tslint.json 'src/**/*.ts'",
+    "lint:fix": "tslint --fix -c tslint.json 'src/**/*.ts'",
     "lint:lockfile": "lockfile-lint --path package-lock.json --type npm --allowed-hosts npm --validate-https --validate-integrity",
     "generate:test:case": "yaml2json examples/nodejs/serverless.yml > tests/fixtures/example.input.service.json",
     "prepare": "husky install"

--- a/tests/fixtures/arm64.output.service.json
+++ b/tests/fixtures/arm64.output.service.json
@@ -24,7 +24,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16XARM64:65"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16XARM64:66"
       ],
       "package": {
         "exclude": [
@@ -52,7 +52,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18XARM64:40"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18XARM64:41"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/debug-log-level.output.service.json
+++ b/tests/fixtures/debug-log-level.output.service.json
@@ -32,7 +32,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:66"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -54,7 +54,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/debug.output.service.json
+++ b/tests/fixtures/debug.output.service.json
@@ -53,7 +53,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:66"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -75,7 +75,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/distributed-tracing-enabled.output.service.json
+++ b/tests/fixtures/distributed-tracing-enabled.output.service.json
@@ -26,7 +26,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:66"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -50,7 +50,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/eu.output.service.json
+++ b/tests/fixtures/eu.output.service.json
@@ -29,7 +29,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:66"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -55,7 +55,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/function-has-layers.output.service.json
+++ b/tests/fixtures/function-has-layers.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
     ],
     "name": "aws",
     "stage": "prod",
@@ -46,7 +46,7 @@
       "runtime": "nodejs18.x",
       "layers": [
         "arn:aws:lambda:us-east-1:123456789012:layer:SomeOtherLayer:1",
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
       ]
     },
     "layer-nodejs18x2": {

--- a/tests/fixtures/include.output.service.json
+++ b/tests/fixtures/include.output.service.json
@@ -43,7 +43,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers":  [
-           "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+           "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
        ],
       "package": { "exclude": [
         "./**",

--- a/tests/fixtures/includes-all-provider-layer.output.service.json
+++ b/tests/fixtures/includes-all-provider-layer.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
     ],
     "name": "aws",
     "stage": "prod",

--- a/tests/fixtures/lambda-extension-disabled.output.service.json
+++ b/tests/fixtures/lambda-extension-disabled.output.service.json
@@ -25,7 +25,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:66"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -49,7 +49,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/lambda-extension-enabled.output.service.json
+++ b/tests/fixtures/lambda-extension-enabled.output.service.json
@@ -24,7 +24,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:66"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -47,7 +47,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/license-key-secret-disabled.output.service.json
+++ b/tests/fixtures/license-key-secret-disabled.output.service.json
@@ -25,7 +25,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:66"
       ],
       "package": {
         "exclude": [
@@ -53,7 +53,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-disabled.output.service.json
+++ b/tests/fixtures/log-disabled.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:66"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -50,7 +50,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/log-ingestion-via-extension.output.service.json
+++ b/tests/fixtures/log-ingestion-via-extension.output.service.json
@@ -28,7 +28,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:66"
       ],
       "package": {
         "exclude": [
@@ -57,7 +57,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-level.output.service.json
+++ b/tests/fixtures/log-level.output.service.json
@@ -31,7 +31,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:66"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -53,7 +53,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment-log-level.output.service.json
+++ b/tests/fixtures/provider-environment-log-level.output.service.json
@@ -34,7 +34,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:66"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -56,7 +56,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment.output.service.json
+++ b/tests/fixtures/provider-environment.output.service.json
@@ -33,7 +33,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:66"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -55,7 +55,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-layer.output.service.json
+++ b/tests/fixtures/provider-layer.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
     ],
     "name": "aws",
     "stage": "prod",

--- a/tests/fixtures/proxy.output.service.json
+++ b/tests/fixtures/proxy.output.service.json
@@ -24,7 +24,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:66"
       ],
       "package": {
         "exclude": [
@@ -52,7 +52,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/stage-included.output.service.json
+++ b/tests/fixtures/stage-included.output.service.json
@@ -30,7 +30,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:66"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -49,7 +49,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/trusted-account-key-excluded.output.service.json
+++ b/tests/fixtures/trusted-account-key-excluded.output.service.json
@@ -29,7 +29,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:66"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -48,7 +48,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/trusted-account-key-included.output.service.json
+++ b/tests/fixtures/trusted-account-key-included.output.service.json
@@ -30,7 +30,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:65"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:66"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -49,7 +49,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:40"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -9,7 +9,7 @@ const {
   groupBy,
   map,
   reduce,
-  omit
+  omit,
 } = require("ramda");
 const { getInstalledPathSync } = require("get-installed-path");
 const NewRelicLambdaLayerPlugin = require("../src/index");
@@ -23,10 +23,7 @@ const fixturesPath = path.resolve(__dirname, "fixtures");
 
 const buildTestCases = () => {
   const testCaseFiles = fs.readdirSync(fixturesPath);
-  const testCaseFileType = compose(
-    nth(1),
-    split(".")
-  );
+  const testCaseFileType = compose(nth(1), split("."));
   const testCaseContentsFromFiles = reduce((acc: object, fileName: string) => {
     const contents = JSON.parse(
       fs.readFileSync(path.resolve(fixturesPath, fileName))
@@ -35,12 +32,7 @@ const buildTestCases = () => {
     return { ...acc, [fileType]: contents };
   }, {});
 
-  const testCaseFilesByName = groupBy(
-    compose(
-      head,
-      split(".")
-    )
-  )(testCaseFiles);
+  const testCaseFilesByName = groupBy(compose(head, split(".")))(testCaseFiles);
   return map((caseName: string) => {
     const testCaseContents = testCaseContentsFromFiles(
       testCaseFilesByName[caseName]
@@ -72,7 +64,7 @@ describe("NewRelicLambdaLayerPlugin", () => {
         plugin.configureLicenseForExtension = jest.fn(() => {});
 
         try {
-          await plugin.hooks['before:deploy:function:packageFunction']();
+          await plugin.hooks["before:deploy:function:packageFunction"]();
         } catch (err) {}
 
         expect(
@@ -82,7 +74,7 @@ describe("NewRelicLambdaLayerPlugin", () => {
               "package",
               "pluginsData",
               "resources",
-              "serviceObject"
+              "serviceObject",
             ],
             serverless.service
           )

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,0 +1,62 @@
+const { getInstalledPathSync } = require("get-installed-path");
+const log = require("@serverless/utils/log");
+
+const serverlessPath = getInstalledPathSync("serverless", { local: true });
+const AwsProvider = require(`${serverlessPath}/lib/plugins/aws/provider`);
+const Serverless = require(`${serverlessPath}/lib/serverless`);
+const Integration = require("../src/integration").default;
+
+const logShim = {
+    error: console.error, // tslint:disable-line
+    warning: console.log, // tslint:disable-line
+    notice: console.log, // tslint:disable-line
+};
+
+// for simulating AWS ListPolicies, just one per page in this test
+const paginatedResults = require("./paginatedResults.json");
+
+const returnPaginatedAwsRequest = (service, method, params) => {
+  if (!params.Marker) {
+    return paginatedResults.first;
+  }
+  return paginatedResults[params.Marker];
+};
+
+describe("Integration functions", () => {
+  const stage = "dev";
+  const commands = [];
+  const config = { commands, options: { stage }, log };
+
+  const serverless = new Serverless(config);
+
+  serverless.setProvider("aws", new AwsProvider(serverless, config));
+  const awsProvider = serverless.getProvider("aws");
+  awsProvider.request = jest.fn(returnPaginatedAwsRequest);
+
+  const pluginMock = {
+    config,
+    awsProvider,
+    serverless,
+    region: "us-east-1",
+    licenseKey: "nr-license-key",
+    log: logShim,
+  };
+
+  const slsIntegration = new Integration(pluginMock);
+
+  describe("checkForManagedSecretPolicy makes a ListPolicies request", () => {
+    it("makes a ListPolicies request, iterating through multiple pages of results", async () => {
+      const existingPolicy = await slsIntegration.checkForManagedSecretPolicy();
+      expect(existingPolicy).toBeDefined();
+      expect(existingPolicy).toHaveProperty([
+        "currentRegionPolicy",
+        0,
+        "PolicyName",
+      ]);
+      expect(existingPolicy.currentRegionPolicy[0].PolicyName).toEqual(
+        paginatedResults.fourth.Policies[0].PolicyName
+      );
+      expect(existingPolicy.secretExists).toBeTruthy();
+    });
+  });
+});

--- a/tests/paginatedResults.json
+++ b/tests/paginatedResults.json
@@ -1,47 +1,146 @@
 {
-  "first": {
-    "Policies": [
-      {
-        "PolicyName": "FirstPolicyName",
-        "Arn": "arn:aws:iam::123456789:policy/service-role/FirstPolicyName-uuid",
-        "Path": "/service-role/"
-      }
-    ],
-    "IsTruncated": true,
-    "Marker": "second"
+  "paginated": {
+    "first": {
+      "Policies": [
+        {
+          "PolicyName": "FirstPolicyName",
+          "Arn": "arn:aws:iam::123456789:policy/service-role/FirstPolicyName",
+          "Path": "/service-role/"
+        }
+      ],
+      "IsTruncated": true,
+      "Marker": "second"
+    },
+    "second": {
+      "Policies": [
+        {
+          "PolicyName": "SecondPolicyName",
+          "Arn": "arn:aws:iam::123456789:policy/service-role/SecondPolicyName",
+          "Path": "/service-role/"
+        }
+      ],
+      "IsTruncated": true,
+      "Marker": "third"
+    },
+    "third": {
+      "Policies": [
+        {
+          "PolicyName": "ThirdPolicyName",
+          "Arn": "arn:aws:iam::123456789:policy/service-role/ThirdPolicyName",
+          "Path": "/service-role/"
+        }
+      ],
+      "IsTruncated": true,
+      "Marker": "fourth"
+    },
+    "fourth": {
+      "Policies": [
+        {
+          "PolicyName": "NewRelic-ViewLicenseKey-us-east-1",
+          "Arn": "arn:aws:iam::123456789:policy/NewRelic-ViewLicenseKey-us-east-1",
+          "Path": "/"
+        }
+      ],
+      "IsTruncated": false,
+      "Marker": "end"
+    }
   },
-  "second": {
-    "Policies": [
-      {
-        "PolicyName": "SecondPolicyName",
-        "Arn": "arn:aws:iam::123456789:policy/service-role/SecondPolicyName-uuid",
-        "Path": "/service-role/"
-      }
-    ],
-    "IsTruncated": true,
-    "Marker": "third"
+  "paginatedNoMatch": {
+    "first": {
+      "Policies": [
+        {
+          "PolicyName": "FirstPolicyName",
+          "Arn": "arn:aws:iam::123456789:policy/service-role/FirstPolicyName",
+          "Path": "/service-role/"
+        }
+      ],
+      "IsTruncated": true,
+      "Marker": "second"
+    },
+    "second": {
+      "Policies": [
+        {
+          "PolicyName": "SecondPolicyName",
+          "Arn": "arn:aws:iam::123456789:policy/service-role/SecondPolicyName",
+          "Path": "/service-role/"
+        }
+      ],
+      "IsTruncated": true,
+      "Marker": "third"
+    },
+    "third": {
+      "Policies": [
+        {
+          "PolicyName": "ThirdPolicyName",
+          "Arn": "arn:aws:iam::123456789:policy/service-role/ThirdPolicyName",
+          "Path": "/service-role/"
+        }
+      ],
+      "IsTruncated": true,
+      "Marker": "fourth"
+    },
+    "fourth": {
+      "Policies": [
+        {
+          "PolicyName": "FourthPolicyName",
+          "Arn": "arn:aws:iam::123456789:policy/FourthPolicyName",
+          "Path": "/"
+        }
+      ],
+      "IsTruncated": false,
+      "Marker": "end"
+    }
   },
-  "third": {
-    "Policies": [
-      {
-        "PolicyName": "ThirdPolicyName",
-        "Arn": "arn:aws:iam::123456789:policy/service-role/ThirdPolicyName-uuid",
-        "Path": "/service-role/"
+  "nonPaginated": {
+      "Policies": [
+        {
+          "PolicyName": "FirstPolicyName",
+          "Arn": "arn:aws:iam::123456789:policy/service-role/FirstPolicyName",
+          "Path": "/service-role/"
+        },
+        {
+          "PolicyName": "SecondPolicyName",
+          "Arn": "arn:aws:iam::123456789:policy/service-role/SecondPolicyName",
+          "Path": "/service-role/"
+        },
+        {
+          "PolicyName": "ThirdPolicyName",
+          "Arn": "arn:aws:iam::123456789:policy/service-role/ThirdPolicyName",
+          "Path": "/service-role/"
+        },
+        {
+          "PolicyName": "NewRelic-ViewLicenseKey-us-east-1",
+          "Arn": "arn:aws:iam::123456789:policy/NewRelic-ViewLicenseKey-us-east-1",
+          "Path": "/"
+        }
+      ],
+      "IsTruncated": false,
+      "Marker": "end"
+    },
+    "nonPaginatedNoMatch": {
+        "Policies": [
+          {
+            "PolicyName": "FirstPolicyName",
+            "Arn": "arn:aws:iam::123456789:policy/service-role/FirstPolicyName",
+            "Path": "/service-role/"
+          },
+          {
+            "PolicyName": "SecondPolicyName",
+            "Arn": "arn:aws:iam::123456789:policy/service-role/SecondPolicyName",
+            "Path": "/service-role/"
+          },
+          {
+            "PolicyName": "ThirdPolicyName",
+            "Arn": "arn:aws:iam::123456789:policy/service-role/ThirdPolicyName",
+            "Path": "/service-role/"
+          },
+          {
+            "PolicyName": "FourthPolicyName",
+            "Arn": "arn:aws:iam::123456789:policy/FourthPolicyName",
+            "Path": "/"
+          }
+        ],
+        "IsTruncated": false,
+        "Marker": "end"
       }
-    ],
-    "IsTruncated": true,
-    "Marker": "fourth"
-  },
-  "fourth": {
-    "Policies": [
-      {
-        "PolicyName": "NewRelic-ViewLicenseKey-us-east-1",
-        "PolicyId": "0987654321",
-        "Arn": "arn:aws:iam::123456789:policy/NewRelic-ViewLicenseKey-us-east-1",
-        "Path": "/"
-      }
-    ],
-    "IsTruncated": false,
-    "Marker": "end"
-  }
-}
+    }

--- a/tests/paginatedResults.json
+++ b/tests/paginatedResults.json
@@ -1,0 +1,47 @@
+{
+  "first": {
+    "Policies": [
+      {
+        "PolicyName": "FirstPolicyName",
+        "Arn": "arn:aws:iam::123456789:policy/service-role/FirstPolicyName-uuid",
+        "Path": "/service-role/"
+      }
+    ],
+    "IsTruncated": true,
+    "Marker": "second"
+  },
+  "second": {
+    "Policies": [
+      {
+        "PolicyName": "SecondPolicyName",
+        "Arn": "arn:aws:iam::123456789:policy/service-role/SecondPolicyName-uuid",
+        "Path": "/service-role/"
+      }
+    ],
+    "IsTruncated": true,
+    "Marker": "third"
+  },
+  "third": {
+    "Policies": [
+      {
+        "PolicyName": "ThirdPolicyName",
+        "Arn": "arn:aws:iam::123456789:policy/service-role/ThirdPolicyName-uuid",
+        "Path": "/service-role/"
+      }
+    ],
+    "IsTruncated": true,
+    "Marker": "fourth"
+  },
+  "fourth": {
+    "Policies": [
+      {
+        "PolicyName": "NewRelic-ViewLicenseKey-us-east-1",
+        "PolicyId": "0987654321",
+        "Arn": "arn:aws:iam::123456789:policy/NewRelic-ViewLicenseKey-us-east-1",
+        "Path": "/"
+      }
+    ],
+    "IsTruncated": false,
+    "Marker": "end"
+  }
+}


### PR DESCRIPTION
Customers with more than 100 locally-scoped IAM policies could encounter an error in which the plugin tries to recreate the secret access policy. This change follows the ListPolicies pagination standard. 

Closes #357 
Closes NR-154677