### PR TITLE
feat: Added manualWrapping flag to skip wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,17 @@ Logging configuration is considered in the following order:
 3. custom newRelic `logLevel` property
 4. custom newRelic `debug` flag
 
+
+#### `manualWrapping` (optional)
+
+Functions with many dependencies may experience longer cold start times with dynamic wrapping. One possible remediation is to [wrap the function manually[(https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy/#node), and bypass the no-code-change wrapping. If you enable this option, you'll need to `require` (or, for ESM, `import`) the New Relic Node Agent, and wrap the body of your handler function. You would still be able to take advantage of the easy installation of the agent via Lambda Layers, and still have telemetry transported to New Relic via the Lambda Extension. We recommend that you include the New Relic Node Agent as a devDependency for local development, and omit it from the dependencies you deploy.  Defaults to `false`. 
+
+```yaml
+custom:
+  newRelic:
+    manualWrapping: true
+```
+
 #### `customRolePolicy` (optional)
 
 Specify an alternative IAM role policy ARN for this integration here if you do not want to use the default role policy.

--- a/examples/nodejs/serverless.yml
+++ b/examples/nodejs/serverless.yml
@@ -23,7 +23,7 @@ custom:
     logLevel: debug
 
 functions:
-  layer-nodejs12x:
+  layer-nodejs16x:
     events:
       - schedule: rate(5 minutes)
     handler: handler.handler
@@ -32,9 +32,9 @@ functions:
         - ./**
       include:
         - handler.js
-    runtime: nodejs12.x
+    runtime: nodejs16.x
 
-  layer-nodejs14x:
+  layer-nodejs18x:
     events:
       - schedule: rate(5 minutes)
     handler: handler.handler
@@ -43,4 +43,4 @@ functions:
         - ./**
       include:
         - handler.js
-    runtime: nodejs14.x
+    runtime: nodejs18.x

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -628,8 +628,13 @@ or make sure that you already have Serverless 3.x installed in your project.
     }
 
     funcDef.environment = environment;
-    funcDef.handler = this.getHandlerWrapper(runtime, handler);
-    funcDef.package = this.updatePackageExcludes(runtime, pkg);
+
+    // Skip auto-wrapping if the function code is wrapped manually and manualWrapping is true
+    // It's assumed that manually-wrapped functions still use the layer, env vars, and permissions
+    if (!this.config.manualWrapping || this.config.manualWrapping === "false") {
+      funcDef.handler = this.getHandlerWrapper(runtime, handler);
+      funcDef.package = this.updatePackageExcludes(runtime, pkg);
+    }
   }
 
   private shouldSkipPlugin() {
@@ -744,11 +749,7 @@ or make sure that you already have Serverless 3.x installed in your project.
   }
 
   private getHandlerWrapper(runtime: string, handler: string) {
-    if (
-      ["nodejs12.x", "nodejs14.x", "nodejs16.x", "nodejs18.x"].indexOf(
-        runtime
-      ) !== -1
-    ) {
+    if (["nodejs14.x", "nodejs16.x", "nodejs18.x"].indexOf(runtime) !== -1) {
       return "newrelic-lambda-wrapper.handler";
     }
 

--- a/tests/fixtures/manual-wrapping.input.service.json
+++ b/tests/fixtures/manual-wrapping.input.service.json
@@ -1,0 +1,35 @@
+{
+  "service": "newrelic-lambda-layers-nodejs-example",
+  "provider": {
+    "name": "aws",
+    "stage": "prod",
+    "region": "us-east-1",
+    "stackTags": {
+      "environment": "us-testing",
+      "owning_team": "LAMBDA",
+      "product": "aws-lambda"
+    },
+    "tags": {
+      "environment": "us-testing",
+      "owning_team": "LAMBDA",
+      "product": "aws-lambda"
+    }
+  },
+  "plugins": ["serverless-newrelic-lambda-layers"],
+  "custom": {
+    "newRelic": {
+      "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
+      "apiKey": "${env:NEW_RELIC_PERSONAL_API_KEY}",
+      "logLevel": "debug",
+      "manualWrapping": true
+    }
+  },
+  "functions": {
+    "layer-nodejs18x": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs18.x"
+    }
+  }
+}

--- a/tests/fixtures/manual-wrapping.output.service.json
+++ b/tests/fixtures/manual-wrapping.output.service.json
@@ -1,0 +1,60 @@
+{
+  "configValidationMode": "warn",
+  "custom": {
+    "newRelic": {
+      "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
+      "apiKey": "${env:NEW_RELIC_PERSONAL_API_KEY}",
+      "logLevel": "debug",
+      "manualWrapping": true
+    }
+  },
+  "disabledDeprecations": [],
+  "functions": {
+    "layer-nodejs18x": {
+      "environment": {
+        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
+        "NEW_RELIC_APP_NAME": "layer-nodejs18x",
+        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
+        "NEW_RELIC_NO_CONFIG_FILE": "true",
+        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
+      },
+      "events": [
+        {
+          "schedule": "rate(5 minutes)"
+        }
+      ],
+      "handler": "handler.handler",
+      "package": {
+        "exclude": [
+          "./**"
+        ],
+        "include": [
+          "handler.js"
+        ]
+      },
+      "runtime": "nodejs18.x"
+    }
+  },
+  "plugins": [
+    "serverless-newrelic-lambda-layers"
+  ],
+  "provider": {
+    "layers": [
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:41"
+    ],
+    "name": "aws",
+    "region": "us-east-1",
+    "stackTags": {
+      "environment": "us-testing",
+      "owning_team": "LAMBDA",
+      "product": "aws-lambda"
+    },
+    "stage": "prod",
+    "tags": {
+      "environment": "us-testing",
+      "owning_team": "LAMBDA",
+      "product": "aws-lambda"
+    }
+  },
+  "service": "newrelic-lambda-layers-nodejs-example"
+}


### PR DESCRIPTION
Some functions with many dependencies may see longer cold-start times due to the need to load them all in before the function's invoked. For those situations, we're adding the ability to skip dynamic wrapping, on the assumption that the user will wrap manually. Even if we avoid dynamic wrapping, the user can still take advantage of the plugin's automatic setting of environment variables, getting the latest layer, and setting up access to the license key. 

Closes #377 
Closes NR-152247