### PR TITLE
Handle null account values returned from NR API. -> v3.5.0

### DIFF
--- a/src/integration.ts
+++ b/src/integration.ts
@@ -56,6 +56,7 @@ export default class Integration {
 
     const match = linkedAccounts.filter((account) => {
       return (
+        account &&
         account.externalId === externalId &&
         account.nrAccountId === parseInt(accountId, 10)
       );


### PR DESCRIPTION
Replicate this fix applied on v4x, to v3.5.0

[Handle null account values returned from NR API.](https://github.com/newrelic/serverless-newrelic-lambda-layers/commit/a24c2900a1e0ac6d392eb3b128d6ce7739f3f0d9)