### PR TITLE
chore!: Dropped support for Node 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,6 @@ custom:
 
 This plugin currently supports the following AWS runtimes:
 
-- nodejs14.x
 - nodejs16.x
 - nodejs18.x
 - nodejs20.x

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "4.3.0",
+  "version": "5.0.0",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,6 @@ const logShim = {
 };
 
 const wrappableRuntimeList = [
-  "nodejs14.x",
   "nodejs16.x",
   "nodejs18.x",
   "nodejs20.x",
@@ -752,7 +751,7 @@ or make sure that you already have Serverless 3.x installed in your project.
 
   private getHandlerWrapper(runtime: string, handler: string) {
     if (
-      ["nodejs14.x", "nodejs16.x", "nodejs18.x", "nodejs20.x"].indexOf(
+      ["nodejs16.x", "nodejs18.x", "nodejs20.x"].indexOf(
         runtime
       ) !== -1
     ) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -750,11 +750,7 @@ or make sure that you already have Serverless 3.x installed in your project.
   }
 
   private getHandlerWrapper(runtime: string, handler: string) {
-    if (
-      ["nodejs16.x", "nodejs18.x", "nodejs20.x"].indexOf(
-        runtime
-      ) !== -1
-    ) {
+    if (["nodejs16.x", "nodejs18.x", "nodejs20.x"].indexOf(runtime) !== -1) {
       return "newrelic-lambda-wrapper.handler";
     }
 

--- a/tests/fixtures/debug.input.service.json
+++ b/tests/fixtures/debug.input.service.json
@@ -27,12 +27,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs14x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "handler.handler",
-      "package": { "exclude": ["./**"], "include": ["handler.js"] },
-      "runtime": "nodejs14.x"
-    },
     "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "handler.handler",

--- a/tests/fixtures/debug.output.service.json
+++ b/tests/fixtures/debug.output.service.json
@@ -27,28 +27,6 @@
   },
   "disabledDeprecations": [],
   "functions": {
-    "layer-nodejs14x": {
-      "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS14X:118"
-      ],
-      "package": {
-        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
-        "include": ["handler.js"]
-      },
-      "runtime": "nodejs14.x",
-      "environment": {
-        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-        "NEW_RELIC_APP_NAME": "layer-nodejs14x",
-        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_LOG": "stdout",
-        "NEW_RELIC_LOG_ENABLED": "true",
-        "NEW_RELIC_LOG_LEVEL": "debug",
-        "NEW_RELIC_NO_CONFIG_FILE": "true",
-        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
-    },
     "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",


### PR DESCRIPTION
Node 14 is [no longer supported](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) as a Lambda runtime. This PR drops support for it.