### PR TITLE
chore: adds a workflow to add any new issues or prs to our GH engineering board

### DIFF
--- a/.github/workflows/add-to-board.yml
+++ b/.github/workflows/add-to-board.yml
@@ -1,0 +1,15 @@
+name: Auto Assign to Project(s)
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  add-to-board:
+    uses: newrelic/node-newrelic/.github/workflows/board.yml@main
+    # See board.yml explaining why this has to be done
+    secrets:
+      gh_token: ${{ secrets.NODE_AGENT_GH_TOKEN }}
+


### PR DESCRIPTION
This workflow should add all new issues and PRs to our [Node board](https://github.com/orgs/newrelic/projects/41)