### PR TITLE
chore(ci): Reverted ci to GHA v3

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -11,9 +11,9 @@ jobs:
       matrix:
         node-version: [lts/*]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
@@ -30,9 +30,9 @@ jobs:
       matrix:
         node-version: [lts/*]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
@@ -42,7 +42,7 @@ jobs:
       - name: Run Snapshot Tests
         run: npm test
       - name: Upload Unit Test Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage/lcov.info


### PR DESCRIPTION
This plugin's auto-release process is failing validation with GitHub's REST API at the Create Release Notes step (run from the Node Agent's reusable workflow), here: https://github.com/newrelic/node-newrelic/blob/main/bin/prepare-release.js#L184

One difference between this plugin repo and other repos is that the main CI Workflow file has been set to v4 of actions, while the agent uses v3. This repo's prepare-release action isn't initiated from the ci-workflow file, though, so this may not be an important difference. If nothing else, reverting these to v3 will make this repo consistent with other repos. 