### PR TITLE
Allow python 3.12

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ const wrappableRuntimeList = [
   "python3.9",
   "python3.10",
   "python3.11",
+  "python3.12",
   "java8.al2",
   "java11",
   "java17",


### PR DESCRIPTION
python 3.12 is supported from aws and also the layers in nr already exist