### PR TITLE
Add `provided.al2` to supported runtimes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ This plugin currently supports the following AWS runtimes:
 - java11
 - java17
 - java21
+- provided.al2
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ const wrappableRuntimeList = [
   "dotnet6",
   "dotnet7",
   "dotnet8",
+  "provided.al2",
 ];
 
 export default class NewRelicLambdaLayerPlugin {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

This PR adds the `provided.al2` runtime to the `wrappableRuntimeList` maintained in `index.ts`. From my testing, [there are NewRelic layers supporting this runtime](https://us-east-2.layers.newrelic-external.com/get-layers?CompatibleRuntime=provided.al2).

## How to Test

I used the version of the package in this PR to deploy an application, and verified that logs were being forwarded.

## Related Issues

N/A