### PR TITLE
feat: add provided.al2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ This plugin currently supports the following AWS runtimes:
 - java17
 - java21
 - provided.al2
+- provided.al2023
 
 ## Contributing
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ const wrappableRuntimeList = [
   "dotnet7",
   "dotnet8",
   "provided.al2",
+  "provided.al2023",
 ];
 
 export default class NewRelicLambdaLayerPlugin {


### PR DESCRIPTION
- provided.al2023 can be used with Go functions
- prevents the following issue

    ```
    Warning: Unsupported runtime "provided.al2023" for NewRelic layer; skipping.
    ```

- depends on an update to supported runtimes for the extension
https://github.com/newrelic/newrelic-lambda-layers/issues/268