### PR TITLE
chore: Add .NET 9 to list of wrappable runtimes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ const wrappableRuntimeList = [
   "dotnet6",
   "dotnet7",
   "dotnet8",
+  "dotnet9",
   "provided.al2",
   "provided.al2023",
 ];


### PR DESCRIPTION
.NET 9 went GA last week and we want to support it for .NET Lambdas.

