### PR TITLE
feat: Adding support to Node js v22 runtime and updating test cases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ This plugin currently supports the following AWS runtimes:
 - nodejs16.x
 - nodejs18.x
 - nodejs20.x
+- nodejs22.x
 - python3.7
 - python3.8
 - python3.9

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "node-fetch": "^2.6.7",
         "path": "^0.12.7",
         "semver": "^7.5.4",
-        "serverless": "4.x || 3.x || 2.x || 1.x"
+        "serverless": "4.x || 3.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "node-fetch": "^2.6.7",
     "path": "^0.12.7",
     "semver": "^7.5.4",
-    "serverless": "4.x || 3.x || 2.x || 1.x"
+    "serverless": "4.x || 3.x"
   },
   "keywords": [
     "lambda",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ const wrappableRuntimeList = [
   "nodejs16.x",
   "nodejs18.x",
   "nodejs20.x",
+  "nodejs22.x",
   "python3.7",
   "python3.8",
   "python3.9",

--- a/tests/fixtures/arm64.output.service.json
+++ b/tests/fixtures/arm64.output.service.json
@@ -52,7 +52,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18XARM64:94"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18XARM64:95"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/debug-log-level.output.service.json
+++ b/tests/fixtures/debug-log-level.output.service.json
@@ -54,7 +54,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/debug.output.service.json
+++ b/tests/fixtures/debug.output.service.json
@@ -53,7 +53,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/distributed-tracing-enabled.output.service.json
+++ b/tests/fixtures/distributed-tracing-enabled.output.service.json
@@ -50,7 +50,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-       "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+       "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/eu.output.service.json
+++ b/tests/fixtures/eu.output.service.json
@@ -55,7 +55,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/function-has-layers.output.service.json
+++ b/tests/fixtures/function-has-layers.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-     "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+     "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
     ],
     "name": "aws",
     "stage": "prod",
@@ -46,7 +46,7 @@
       "runtime": "nodejs18.x",
       "layers": [
         "arn:aws:lambda:us-east-1:123456789012:layer:SomeOtherLayer:1",
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
       ]
     },
     "layer-nodejs18x2": {

--- a/tests/fixtures/include.output.service.json
+++ b/tests/fixtures/include.output.service.json
@@ -43,7 +43,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers":  [
-            "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+            "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
        ],
       "package": { "exclude": [
         "./**",

--- a/tests/fixtures/includes-all-provider-layer.output.service.json
+++ b/tests/fixtures/includes-all-provider-layer.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
     ],
     "name": "aws",
     "stage": "prod",

--- a/tests/fixtures/lambda-extension-disabled.output.service.json
+++ b/tests/fixtures/lambda-extension-disabled.output.service.json
@@ -49,7 +49,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/lambda-extension-enabled.output.service.json
+++ b/tests/fixtures/lambda-extension-enabled.output.service.json
@@ -47,7 +47,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/license-key-secret-disabled.output.service.json
+++ b/tests/fixtures/license-key-secret-disabled.output.service.json
@@ -53,7 +53,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-disabled.output.service.json
+++ b/tests/fixtures/log-disabled.output.service.json
@@ -50,7 +50,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/log-ingestion-via-extension.output.service.json
+++ b/tests/fixtures/log-ingestion-via-extension.output.service.json
@@ -57,7 +57,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-level.output.service.json
+++ b/tests/fixtures/log-level.output.service.json
@@ -53,7 +53,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/manual-wrapping.output.service.json
+++ b/tests/fixtures/manual-wrapping.output.service.json
@@ -40,7 +40,7 @@
   ],
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
     ],
     "name": "aws",
     "region": "us-east-1",

--- a/tests/fixtures/node-versions.input.service.json
+++ b/tests/fixtures/node-versions.input.service.json
@@ -75,6 +75,23 @@
         ]
       },
       "runtime": "nodejs20.x"
+    },
+    "layer-nodejs22x": {
+      "events": [
+        {
+          "schedule": "rate(5 minutes)"
+        }
+      ],
+      "handler": "handler.handler",
+      "package": {
+        "exclude": [
+          "./**"
+        ],
+        "include": [
+          "handler.js"
+        ]
+      },
+      "runtime": "nodejs22.x"
     }
   }
 }

--- a/tests/fixtures/node-versions.output.service.json
+++ b/tests/fixtures/node-versions.output.service.json
@@ -67,7 +67,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS20X:44"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS20X:45"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -84,7 +84,7 @@
     },
     "layer-nodejs22x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-lambda-wrapper.handler",
+      "handler": "handler.handler",
       "layers": [
         "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS22X:1"
       ],

--- a/tests/fixtures/node-versions.output.service.json
+++ b/tests/fixtures/node-versions.output.service.json
@@ -48,7 +48,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -77,6 +77,25 @@
       "environment": {
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
         "NEW_RELIC_APP_NAME": "layer-nodejs20x",
+        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
+        "NEW_RELIC_NO_CONFIG_FILE": "true",
+        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
+      }
+    },
+    "layer-nodejs22x": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "newrelic-lambda-wrapper.handler",
+      "layers": [
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS22X:1"
+      ],
+      "package": {
+        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
+        "include": ["handler.js"]
+      },
+      "runtime": "nodejs22.x",
+      "environment": {
+        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
+        "NEW_RELIC_APP_NAME": "layer-nodejs22x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"

--- a/tests/fixtures/provider-environment-log-level.output.service.json
+++ b/tests/fixtures/provider-environment-log-level.output.service.json
@@ -56,7 +56,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment.output.service.json
+++ b/tests/fixtures/provider-environment.output.service.json
@@ -55,7 +55,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-layer.output.service.json
+++ b/tests/fixtures/provider-layer.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
     ],
     "name": "aws",
     "stage": "prod",

--- a/tests/fixtures/proxy.output.service.json
+++ b/tests/fixtures/proxy.output.service.json
@@ -52,7 +52,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/stage-included.output.service.json
+++ b/tests/fixtures/stage-included.output.service.json
@@ -49,7 +49,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-       "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+       "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/trusted-account-key-excluded.output.service.json
+++ b/tests/fixtures/trusted-account-key-excluded.output.service.json
@@ -48,7 +48,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/trusted-account-key-included.output.service.json
+++ b/tests/fixtures/trusted-account-key-included.output.service.json
@@ -49,7 +49,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:94"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:95"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],


### PR DESCRIPTION
## Description
- This PR helps to support the Nodejs v22 runtime.
- Updates few test cases
- remove serverless v1 and v2 since we support serverless v3 and v4.