### PR TITLE
feat: added feature to add nrTags and customise nrEnvDelimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,22 @@ custom:
     enableExtensionLogs: false
 ```
 
+#### `nrTags` (optional)
+Specify tags to be added to all log events. Optional. Each tag is composed of a colon-delimited key and value. Multiple key-value pairs are semicolon-delimited; for example, env:prod;team:myTeam.
+```yaml
+custom:
+  newRelic:
+    nrTags:'env:prod;team:myTeam'
+```
+
+#### `nrEnvDelimiter` (optional)
+Some users in UTF-8 environments might face difficulty in defining strings of `NR_TAGS` delimited by the semicolon `;` character. Use NR_ENV_DELIMITER, to set custom delimiter for `NR_TAGS`.
+```yaml
+custom:
+  newRelic:
+    nrEnvDelimiter:','
+```
+
 #### `logEnabled` (optional)
 
 Enables logging when using CloudWatch-based telemetry transport with the newrelic-log-ingestion Lambda function. Defaults to `false`

--- a/src/index.ts
+++ b/src/index.ts
@@ -559,6 +559,12 @@ or make sure that you already have Serverless 3.x installed in your project.
       (this.config.enableExtension === "false" ||
         this.config.enableExtension === false);
 
+    if (!_.isUndefined(this.config.nrTags)) {
+      environment.NR_TAGS = this.config.nrTags;
+    }
+    if (!_.isUndefined(this.config.nrEnvDelimiter)) {
+      environment.NR_ENV_DELIMETER = this.config.nrEnvDelimiter;
+    }
     if (extensionDisabled) {
       environment.NEW_RELIC_LAMBDA_EXTENSION_ENABLED = "false";
     } else {


### PR DESCRIPTION
### Description

This PR introduces two new optional configurations to enhance log event tagging for New Relic:

#### `nrTags` (optional)
- Allows specifying tags to be added to all log events.
- Tags are formatted as colon-delimited key-value pairs.
- Multiple key-value pairs can be separated by semicolons (`;`).
- Example usage:
  ```yaml
  custom:
    newRelic:
      nrTags: 'env:prod;team:myTeam'
  ```

#### `nrEnvDelimiter` (optional)
- Provides an alternative delimiter option for `NR_TAGS`, useful for UTF-8 environments where semicolon (`;`) may cause issues.
- Lets users set a custom delimiter instead of using the default semicolon.
- Example usage:
  ```yaml
  custom:
    newRelic:
      nrEnvDelimiter: ','
  ```
### Issues
Resolves #492 