### PR TITLE
add sendFunctionLogs & sendExtensionLogs config params

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,26 @@ custom:
   newRelic:
     enableExtension: true
 ```
+
+#### `sendFunctionLogs` (optional)
+
+Allows your function to deliver all of your function logs to New Relic via AWS Lambda Extension. The `sendFunctionLogs` config works identically to the older `enableFunctionLogs`. This new config has been introduced for consistency with `sendExtensionLogs`. While the new naming provides improved clarity, `enableFunctionLogs` remains available to ensure backward compatibility.
+
+```yaml
+custom:
+  newRelic:
+    sendFunctionLogs: true
+```
+
+#### `sendExtensionLogs` (optional)
+Allows your function to deliver all of your `extension logs` to New Relic via AWS Lambda Extension. 
+
+```yaml
+custom:
+  newRelic:
+    enableFunctionLogs: true
+```
+
 #### `enableFunctionLogs` (optional)
 
 Allows your function to deliver all of your function logs to New Relic via AWS Lambda Extension. This would eliminate the need for a CloudWatch log subscription + the NR log ingestion Lambda function. This method of log ingestion is lower-cost, and offers faster time to glass.  

--- a/src/index.ts
+++ b/src/index.ts
@@ -575,6 +575,22 @@ or make sure that you already have Serverless 3.x installed in your project.
       }
 
       if (
+        this.config.sendFunctionLogs &&
+        this.config.sendFunctionLogs !== "false"
+      ) {
+        environment.NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS = "true";
+        this.config.disableAutoSubscription = true;
+      }
+
+      if (
+        this.config.sendExtensionLogs &&
+        this.config.sendExtensionLogs !== "false"
+      ) {
+        environment.NEW_RELIC_EXTENSION_SEND_EXTENSION_LOGS = "true";
+        this.config.disableAutoSubscription = true;
+      }
+
+      if (
         !_.isUndefined(this.config.enableExtensionLogs) &&
         (this.config.enableExtensionLogs === "false" ||
           this.config.enableExtensionLogs === false)


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

- Adds config param to `sendFunctionLogs` & `sendExtensionLogs`
- `sendFunctionLogs` has been introduced to ensure consistency with `sendExtensionLogs`
- The old config param `enableFunctionLogs` remains available to ensure backward compatibility

## How to Test

Test Lambda was created using the modified plugin changes to check if all config parameters  `sendFunctionLogs` , `sendExtensionLogs` and `enableFunctionLogs` are working as required.

## Related Issues

Please include any related issues or pull requests in this section, using the format `Closes #<issue number>` or `Fixes #<issue number>` if applicable.