### PR TITLE
chore: Updated Serverless version in examples

### DIFF
--- a/examples/nodejs/package.json
+++ b/examples/nodejs/package.json
@@ -13,6 +13,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "serverless": "^3.3.0"
+    "serverless": "^4.12.0"
   }
 }

--- a/examples/python-requirements/package.json
+++ b/examples/python-requirements/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "serverless": "^4.9.0",
+    "serverless": "^4.12.0",
     "serverless-python-requirements": "^5.3.1"
   }
 }

--- a/examples/python/package.json
+++ b/examples/python/package.json
@@ -13,6 +13,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "serverless": "^3.3.0"
+    "serverless": "^4.12.0"
   }
 }


### PR DESCRIPTION
## Description

[Serverless](https://www.serverless.com/) version in the following examples were updated to latest version of `4.12.0`:

- Python
- Python-requirements
- Nodejs


