### PR TITLE
feat: Support for Ingest Key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/jest": "^29.2.0",
         "@types/lodash": "^4.14.186",
         "@types/node": "^18.11.6",
-        "@types/node-fetch": "^2.6.2",
+        "@types/node-fetch": "2.6.2",
         "@types/ramda": "^0.28.18",
         "get-installed-path": "^4.0.8",
         "husky": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/jest": "^29.2.0",
     "@types/lodash": "^4.14.186",
     "@types/node": "^18.11.6",
-    "@types/node-fetch": "^2.6.2",
+    "@types/node-fetch": "2.6.2",
     "@types/ramda": "^0.28.18",
     "get-installed-path": "^4.0.8",
     "husky": "^8.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,7 +202,12 @@ https://blog.newrelic.com/product-news/aws-lambda-extensions-integrations/
 
   public async configureLicenseForExtension() {
     if (!this.licenseKey) {
-      this.licenseKey = await this.retrieveLicenseKey();
+      if (this.config.ingestKey) {
+        this.licenseKey = this.config.ingestKey;
+        this.log.notice("Using ingest key as license key.");
+      } else {
+        this.licenseKey = await this.retrieveLicenseKey();
+      }
       if (!this.licenseKey) {
         this.config.enableExtension = false;
         this.extFellBackToCW = true;
@@ -311,7 +316,7 @@ or make sure that you already have Serverless 3.x installed in your project.
       return;
     }
 
-    if (!this.config.apiKey) {
+    if (!this.config.apiKey && !this.config.ingestKey) {
       this.log.error(
         `Please use a valid New Relic API key as your apiKey value; skipping.`
       );
@@ -321,7 +326,7 @@ or make sure that you already have Serverless 3.x installed in your project.
     const { exclude = [], include = [] } = this.config;
     if (!_.isEmpty(exclude) && !_.isEmpty(include)) {
       this.log.error(
-        "exclude and include options are mutually exclusive; skipping."
+        "exclude and include options are mutually exclusive or a valid New Relic Ingest Key as ingestKey; skipping."
       );
       return;
     }

--- a/tests/fixtures/api-and-ingest-key.input.service.json
+++ b/tests/fixtures/api-and-ingest-key.input.service.json
@@ -16,15 +16,14 @@
     }
   },
   "plugins": ["serverless-newrelic-lambda-layers"],
-  "configValidationMode": "warn",
   "custom": {
     "newRelic": {
       "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
-      "apiKey": "${env:NEW_RELIC_PERSONAL_API_KEY}",
-      "include": ["layer-nodejs18x"]
+      "apiKey": "test-api-key",
+      "ingestKey": "test-ingest-key",
+      "logLevel": "debug"
     }
   },
-  "disabledDeprecations": [],
   "functions": {
     "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
@@ -33,22 +32,9 @@
       "runtime": "nodejs16.x"
     },
     "layer-nodejs18x": {
-       "environment": {
-         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-         "NEW_RELIC_APP_NAME": "layer-nodejs18x",
-         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-         "NEW_RELIC_NO_CONFIG_FILE": "true",
-         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-       },
       "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers":  [
-            "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
-       ],
-      "package": { "exclude": [
-        "./**",
-        "!newrelic-wrapper-helper.js"
-      ], "include": ["handler.js"] },
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
       "runtime": "nodejs18.x"
     }
   }

--- a/tests/fixtures/api-and-ingest-key.output.service.json
+++ b/tests/fixtures/api-and-ingest-key.output.service.json
@@ -20,9 +20,9 @@
   "custom": {
     "newRelic": {
       "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
-      "apiKey": "${env:NEW_RELIC_PERSONAL_API_KEY}",
-      "debug": true,
-      "logEnabled": true
+      "apiKey": "test-api-key",
+      "ingestKey": "test-ingest-key",
+      "logLevel": "debug"
     }
   },
   "disabledDeprecations": [],
@@ -30,9 +30,6 @@
     "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:103"
-      ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
@@ -42,19 +39,17 @@
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
         "NEW_RELIC_APP_NAME": "layer-nodejs16x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_LOG": "stdout",
-        "NEW_RELIC_LOG_ENABLED": "true",
-        "NEW_RELIC_LOG_LEVEL": "debug",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
+
+      },
+      "layers": [
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:103"
+      ]
     },
     "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
-      ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
@@ -64,12 +59,12 @@
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
         "NEW_RELIC_APP_NAME": "layer-nodejs18x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_LOG": "stdout",
-        "NEW_RELIC_LOG_ENABLED": "true",
-        "NEW_RELIC_LOG_LEVEL": "debug",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
+      },
+      "layers": [
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
+      ]
     }
   }
 }

--- a/tests/fixtures/arm64.output.service.json
+++ b/tests/fixtures/arm64.output.service.json
@@ -52,7 +52,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-          "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18XARM64:115"
+          "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18XARM64:127"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/debug-log-level.output.service.json
+++ b/tests/fixtures/debug-log-level.output.service.json
@@ -54,7 +54,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/distributed-tracing-enabled.output.service.json
+++ b/tests/fixtures/distributed-tracing-enabled.output.service.json
@@ -50,7 +50,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-       "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+       "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/eu.output.service.json
+++ b/tests/fixtures/eu.output.service.json
@@ -55,7 +55,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/function-has-layers.output.service.json
+++ b/tests/fixtures/function-has-layers.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-     "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+     "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
     ],
     "name": "aws",
     "stage": "prod",
@@ -46,7 +46,7 @@
       "runtime": "nodejs18.x",
       "layers": [
         "arn:aws:lambda:us-east-1:123456789012:layer:SomeOtherLayer:1",
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
       ]
     },
     "layer-nodejs18x2": {

--- a/tests/fixtures/includes-all-provider-layer.output.service.json
+++ b/tests/fixtures/includes-all-provider-layer.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
     ],
     "name": "aws",
     "stage": "prod",

--- a/tests/fixtures/ingest-key-only.input.service.json
+++ b/tests/fixtures/ingest-key-only.input.service.json
@@ -16,15 +16,13 @@
     }
   },
   "plugins": ["serverless-newrelic-lambda-layers"],
-  "configValidationMode": "warn",
   "custom": {
     "newRelic": {
       "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
-      "apiKey": "${env:NEW_RELIC_PERSONAL_API_KEY}",
-      "include": ["layer-nodejs18x"]
+      "ingestKey": "test-ingest-key",
+      "logLevel": "debug"
     }
   },
-  "disabledDeprecations": [],
   "functions": {
     "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
@@ -33,22 +31,9 @@
       "runtime": "nodejs16.x"
     },
     "layer-nodejs18x": {
-       "environment": {
-         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
-         "NEW_RELIC_APP_NAME": "layer-nodejs18x",
-         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-         "NEW_RELIC_NO_CONFIG_FILE": "true",
-         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-       },
       "events": [{ "schedule": "rate(5 minutes)" }],
-      "handler": "newrelic-lambda-wrapper.handler",
-      "layers":  [
-            "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
-       ],
-      "package": { "exclude": [
-        "./**",
-        "!newrelic-wrapper-helper.js"
-      ], "include": ["handler.js"] },
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
       "runtime": "nodejs18.x"
     }
   }

--- a/tests/fixtures/ingest-key-only.output.service.json
+++ b/tests/fixtures/ingest-key-only.output.service.json
@@ -20,9 +20,8 @@
   "custom": {
     "newRelic": {
       "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
-      "apiKey": "${env:NEW_RELIC_PERSONAL_API_KEY}",
-      "debug": true,
-      "logEnabled": true
+      "ingestKey": "test-ingest-key",
+      "logLevel": "debug"
     }
   },
   "disabledDeprecations": [],
@@ -30,9 +29,6 @@
     "layer-nodejs16x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:103"
-      ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
@@ -42,19 +38,17 @@
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
         "NEW_RELIC_APP_NAME": "layer-nodejs16x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_LOG": "stdout",
-        "NEW_RELIC_LOG_ENABLED": "true",
-        "NEW_RELIC_LOG_LEVEL": "debug",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
+
+      },
+      "layers": [
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS16X:103"
+      ]
     },
     "layer-nodejs18x": {
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
-      "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
-      ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
         "include": ["handler.js"]
@@ -64,12 +58,13 @@
         "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
         "NEW_RELIC_APP_NAME": "layer-nodejs18x",
         "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
-        "NEW_RELIC_LOG": "stdout",
-        "NEW_RELIC_LOG_ENABLED": "true",
-        "NEW_RELIC_LOG_LEVEL": "debug",
         "NEW_RELIC_NO_CONFIG_FILE": "true",
         "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
-      }
+
+      },
+      "layers": [
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
+      ]
     }
   }
 }

--- a/tests/fixtures/lambda-extension-disabled.output.service.json
+++ b/tests/fixtures/lambda-extension-disabled.output.service.json
@@ -49,7 +49,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/lambda-extension-enabled.output.service.json
+++ b/tests/fixtures/lambda-extension-enabled.output.service.json
@@ -47,7 +47,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/license-key-secret-disabled.output.service.json
+++ b/tests/fixtures/license-key-secret-disabled.output.service.json
@@ -53,7 +53,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-disabled.output.service.json
+++ b/tests/fixtures/log-disabled.output.service.json
@@ -50,7 +50,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/log-ingestion-via-extension.output.service.json
+++ b/tests/fixtures/log-ingestion-via-extension.output.service.json
@@ -57,7 +57,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/log-level.output.service.json
+++ b/tests/fixtures/log-level.output.service.json
@@ -53,7 +53,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/manual-wrapping.output.service.json
+++ b/tests/fixtures/manual-wrapping.output.service.json
@@ -40,7 +40,7 @@
   ],
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
     ],
     "name": "aws",
     "region": "us-east-1",

--- a/tests/fixtures/node-versions.output.service.json
+++ b/tests/fixtures/node-versions.output.service.json
@@ -48,7 +48,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -67,7 +67,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS20X:65"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS20X:78"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -86,7 +86,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS22X:21"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS22X:34"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment-log-level.output.service.json
+++ b/tests/fixtures/provider-environment-log-level.output.service.json
@@ -56,7 +56,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-environment.output.service.json
+++ b/tests/fixtures/provider-environment.output.service.json
@@ -55,7 +55,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/provider-layer.output.service.json
+++ b/tests/fixtures/provider-layer.output.service.json
@@ -2,7 +2,7 @@
   "service": "newrelic-lambda-layers-nodejs-example",
   "provider": {
     "layers": [
-      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+      "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
     ],
     "name": "aws",
     "stage": "prod",

--- a/tests/fixtures/proxy.output.service.json
+++ b/tests/fixtures/proxy.output.service.json
@@ -52,7 +52,7 @@
       ],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
       ],
       "package": {
         "exclude": [

--- a/tests/fixtures/stage-included.output.service.json
+++ b/tests/fixtures/stage-included.output.service.json
@@ -49,7 +49,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-       "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+       "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/trusted-account-key-excluded.output.service.json
+++ b/tests/fixtures/trusted-account-key-excluded.output.service.json
@@ -48,7 +48,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/trusted-account-key-included.output.service.json
+++ b/tests/fixtures/trusted-account-key-included.output.service.json
@@ -49,7 +49,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:115"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS18X:127"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],


### PR DESCRIPTION
## Ticket: [NR-440836](https://new-relic.atlassian.net/browse/NR-440836)

## What does this PR do?
This PR introduces support for Ingest license keys in the CLI, allowing customers to use `Ingest` keys in their serverless configurations. 

## How to test
To test the new Ingest key support:

- Update your serverless.yml configuration file.
- Replace the variable apikey with ingestKey.
- Assign your Ingest Key to the ingestKey field.

```
custom:
  newRelic:
    accountId: <Account-ID>
    ingestKey: <Ingest-Key>
```
Deploy your serverless application to ensure the Ingest key is being used correctly.

## What changes are we doing?
This PR adds support for Ingest license keys by:
 ### License Configuration:
- Update to use ingestKey if available in configureLicenseForExtension.
Key Check Logic:
- Adjust checks to accept either apiKey or ingestKey.
 ### Integration Handling:
- Skip integration checks when using ingestKey.
 ### Logging Enhancements:
- Improve error messages to include ingestKey details.

[NR-440836]: https://new-relic.atlassian.net/browse/NR-440836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ