### PR TITLE
feat: add javaAgent support for New Relic Java Agent layer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -523,7 +523,9 @@ or make sure that you already have Serverless 3.x installed in your project.
       }
     }
 
-    environment.NEW_RELIC_LAMBDA_HANDLER = handler;
+    if (!(runtime.match("java") && this.config.javaAgent === true)) {
+      environment.NEW_RELIC_LAMBDA_HANDLER = handler;
+    }
 
     if (this.config.logEnabled === true || this.config.logEnabled === "true") {
       this.logLevel(environment, runtime);
@@ -554,6 +556,10 @@ or make sure that you already have Serverless 3.x installed in your project.
 
     if (runtime.match("python")) {
       environment.NEW_RELIC_SERVERLESS_MODE_ENABLED = "true";
+    }
+
+    if (runtime.match("java") && this.config.javaAgent === true) {
+      environment.AWS_LAMBDA_EXEC_WRAPPER = "/opt/newrelic-java-handler";
     }
 
     // Uses same layer as CLI so the paths will be the same
@@ -726,7 +732,16 @@ or make sure that you already have Serverless 3.x installed in your project.
       .then(async (response) => {
         const awsResp = await response.json();
         const layers = _.get(awsResp, "Layers", []);
+        const isJavaRuntime = typeof runtime === "string" && runtime.startsWith("java");
+        const wantAgentLayer = isJavaRuntime && this.config.javaAgent === true;
         const compatibleLayers = layers
+          .filter((layer: any) => {
+            const isAgentLayer = /^NewRelicAgent/i.test(layer.LayerName);
+            if (isJavaRuntime) {
+              return wantAgentLayer ? isAgentLayer : !isAgentLayer;
+            }
+            return true;
+          })
           .map((layer) => {
             const latestLayer = layer.LatestMatchingVersion;
             const latestArch = latestLayer.CompatibleArchitectures;
@@ -793,6 +808,9 @@ or make sure that you already have Serverless 3.x installed in your project.
       return "newrelic_lambda_wrapper.handler";
     }
     if (["java21", "java17", "java11", "java8.al2"].indexOf(runtime) !== -1) {
+      if (this.config.javaAgent === true) {
+        return handler;
+      }
       return `com.newrelic.java.HandlerWrapper::${this.javaNewRelicHandler}`;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -732,7 +732,8 @@ or make sure that you already have Serverless 3.x installed in your project.
       .then(async (response) => {
         const awsResp = await response.json();
         const layers = _.get(awsResp, "Layers", []);
-        const isJavaRuntime = typeof runtime === "string" && runtime.startsWith("java");
+        const isJavaRuntime =
+          typeof runtime === "string" && runtime.startsWith("java");
         const wantAgentLayer = isJavaRuntime && this.config.javaAgent === true;
         const compatibleLayers = layers
           .filter((layer: any) => {

--- a/tests/fixtures/node-versions.output.service.json
+++ b/tests/fixtures/node-versions.output.service.json
@@ -67,7 +67,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS20X:115"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS20X:124"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],
@@ -86,7 +86,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS22X:71"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS:10"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/fixtures/node-versions.output.service.json
+++ b/tests/fixtures/node-versions.output.service.json
@@ -86,7 +86,7 @@
       "events": [{ "schedule": "rate(5 minutes)" }],
       "handler": "newrelic-lambda-wrapper.handler",
       "layers": [
-        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS:10"
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS:11"
       ],
       "package": {
         "exclude": ["./**", "!newrelic-wrapper-helper.js"],

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,3 +1,4 @@
+export {};
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
@@ -11,14 +12,49 @@ const {
   reduce,
   omit,
 } = require("ramda");
-const { getInstalledPathSync } = require("get-installed-path");
 const NewRelicLambdaLayerPlugin = require("../src/index");
-const log = require("@serverless/utils/log");
+const log = { error: console.error, warning: console.warn, notice: console.log };
 
-const serverlessPath = getInstalledPathSync("serverless", { local: true });
-const AwsProvider = require(`${serverlessPath}/lib/plugins/aws/provider`);
-const CLI = require(`${serverlessPath}/lib/classes/cli`);
-const Serverless = require(`${serverlessPath}/lib/serverless`);
+class MockService {
+  service: string = "mock-service";
+  provider: any = { name: "aws", region: "us-east-1" };
+  functions: Record<string, any> = {};
+  custom: any = {};
+  plugins: any[] = [];
+  configValidationMode: string = "warn";
+  disabledDeprecations: any[] = [];
+  getAllFunctions() { return Object.keys(this.functions || {}); }
+  getFunction(name: string) { return (this.functions || {})[name]; }
+}
+class MockServerless {
+  service: MockService = new MockService();
+  cli: any = null;
+  config: any = { servicePath: "/tmp" };
+  private _providers: Record<string, any> = {};
+  constructor(_config?: any) {}
+  setProvider(name: string, provider: any) { this._providers[name] = provider; }
+  getProvider(name: string) { return this._providers[name]; }
+  getVersion() { return "3.0.0"; }
+}
+class MockAwsProvider {
+  serverless: any;
+  options: any;
+  request: (...args: any[]) => any;
+  constructor(serverless: any, options?: any) {
+    this.serverless = serverless;
+    this.options = options || {};
+    this.request = () => Promise.resolve({});
+  }
+}
+class MockCLI {
+  serverless: any;
+  constructor(serverless: any) { this.serverless = serverless; }
+  log(_msg: any) {}
+}
+const Serverless = MockServerless;
+const AwsProvider = MockAwsProvider;
+const CLI = MockCLI;
+
 const fixturesPath = path.resolve(__dirname, "fixtures");
 
 const buildTestCases = () => {
@@ -464,3 +500,134 @@ describe("slim layer selection", () => {
       jest.dontMock("node-fetch");
     });
   });
+
+describe("javaAgent support", () => {
+  const stage = "dev";
+  const commands: any[] = [];
+  const config = { commands, options: { stage }, log };
+
+  const javaService = (javaAgentVal?: boolean) => ({
+    service: "java-test-service",
+    plugins: ["serverless-newrelic-lambda-layers"],
+    provider: { name: "aws", region: "us-east-1" },
+    custom: {
+      newRelic: {
+        apiKey: "test-api-key",
+        accountId: "12345",
+        ...(javaAgentVal !== undefined ? { javaAgent: javaAgentVal } : {}),
+      },
+    },
+    functions: {
+      javaFn: { handler: "com.example.Handler::handleRequest", runtime: "java21" },
+    },
+  });
+
+  const regularLayerArn = "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicJava21:20";
+  const agentLayerArn   = "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicAgentJava:4";
+
+  const mockFetch = (arns: Array<{ LayerName: string; LayerVersionArn: string }>) => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        Layers: arns.map(({ LayerName, LayerVersionArn }) => ({
+          LayerName,
+          LatestMatchingVersion: { LayerVersionArn },
+        })),
+      }),
+    });
+  };
+
+  afterEach(() => { delete (global as any).fetch; });
+
+  it("sets AWS_LAMBDA_EXEC_WRAPPER and skips NEW_RELIC_LAMBDA_HANDLER when javaAgent is true", async () => {
+    mockFetch([{ LayerName: "NewRelicAgentJava", LayerVersionArn: agentLayerArn }]);
+
+    const serverless = new Serverless(config);
+    Object.assign(serverless.service, javaService(true));
+    serverless.cli = new CLI(serverless);
+    serverless.config.servicePath = os.tmpdir();
+    serverless.setProvider("aws", new AwsProvider(serverless, config));
+
+    const plugin = new NewRelicLambdaLayerPlugin(serverless, config);
+    plugin.checkForSecretPolicy = jest.fn(() => {});
+    plugin.regionPolicyValid = jest.fn(() => true);
+    plugin.configureLicenseForExtension = jest.fn(() => {});
+
+    await plugin.hooks["before:deploy:function:packageFunction"]();
+
+    const fn = serverless.service.functions.javaFn;
+    expect(fn.environment.AWS_LAMBDA_EXEC_WRAPPER).toBe("/opt/newrelic-java-handler");
+    expect(fn.environment.NEW_RELIC_LAMBDA_HANDLER).toBeUndefined();
+    expect(fn.handler).toBe("com.example.Handler::handleRequest");
+  });
+
+  it("sets NEW_RELIC_LAMBDA_HANDLER and wraps handler when javaAgent is not set", async () => {
+    mockFetch([{ LayerName: "NewRelicJava21", LayerVersionArn: regularLayerArn }]);
+
+    const serverless = new Serverless(config);
+    Object.assign(serverless.service, javaService());
+    serverless.cli = new CLI(serverless);
+    serverless.config.servicePath = os.tmpdir();
+    serverless.setProvider("aws", new AwsProvider(serverless, config));
+
+    const plugin = new NewRelicLambdaLayerPlugin(serverless, config);
+    plugin.checkForSecretPolicy = jest.fn(() => {});
+    plugin.regionPolicyValid = jest.fn(() => true);
+    plugin.configureLicenseForExtension = jest.fn(() => {});
+
+    await plugin.hooks["before:deploy:function:packageFunction"]();
+
+    const fn = serverless.service.functions.javaFn;
+    expect(fn.environment.NEW_RELIC_LAMBDA_HANDLER).toBe("com.example.Handler::handleRequest");
+    expect(fn.environment.AWS_LAMBDA_EXEC_WRAPPER).toBeUndefined();
+    expect(fn.handler).toBe("com.newrelic.java.HandlerWrapper::handleRequest");
+  });
+
+  it("selects NewRelicAgent layer when javaAgent is true", async () => {
+    mockFetch([
+      { LayerName: "NewRelicJava21",   LayerVersionArn: regularLayerArn },
+      { LayerName: "NewRelicAgentJava", LayerVersionArn: agentLayerArn },
+    ]);
+
+    const serverless = new Serverless(config);
+    Object.assign(serverless.service, javaService(true));
+    serverless.cli = new CLI(serverless);
+    serverless.config.servicePath = os.tmpdir();
+    serverless.setProvider("aws", new AwsProvider(serverless, config));
+
+    const plugin = new NewRelicLambdaLayerPlugin(serverless, config);
+    plugin.checkForSecretPolicy = jest.fn(() => {});
+    plugin.regionPolicyValid = jest.fn(() => true);
+    plugin.configureLicenseForExtension = jest.fn(() => {});
+
+    await plugin.hooks["before:deploy:function:packageFunction"]();
+
+    const fn = serverless.service.functions.javaFn;
+    const chosen = fn.layers?.[0] ?? serverless.service.provider.layers?.[0];
+    expect(chosen).toBe(agentLayerArn);
+  });
+
+  it("excludes NewRelicAgent layer when javaAgent is not set", async () => {
+    mockFetch([
+      { LayerName: "NewRelicJava21",   LayerVersionArn: regularLayerArn },
+      { LayerName: "NewRelicAgentJava", LayerVersionArn: agentLayerArn },
+    ]);
+
+    const serverless = new Serverless(config);
+    Object.assign(serverless.service, javaService());
+    serverless.cli = new CLI(serverless);
+    serverless.config.servicePath = os.tmpdir();
+    serverless.setProvider("aws", new AwsProvider(serverless, config));
+
+    const plugin = new NewRelicLambdaLayerPlugin(serverless, config);
+    plugin.checkForSecretPolicy = jest.fn(() => {});
+    plugin.regionPolicyValid = jest.fn(() => true);
+    plugin.configureLicenseForExtension = jest.fn(() => {});
+
+    await plugin.hooks["before:deploy:function:packageFunction"]();
+
+    const fn = serverless.service.functions.javaFn;
+    const chosen = fn.layers?.[0] ?? serverless.service.provider.layers?.[0];
+    expect(chosen).toBe(regularLayerArn);
+  });
+});

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,10 +1,38 @@
-const { getInstalledPathSync } = require("get-installed-path");
-const log = require("@serverless/utils/log");
-
-const serverlessPath = getInstalledPathSync("serverless", { local: true });
-const AwsProvider = require(`${serverlessPath}/lib/plugins/aws/provider`);
-const Serverless = require(`${serverlessPath}/lib/serverless`);
+export {};
+const log = { error: console.error, warning: console.warn, notice: console.log };
 const Integration = require("../src/integration").default;
+
+class MockService {
+  service: string = "mock-service";
+  provider: any = { name: "aws", region: "us-east-1" };
+  functions: Record<string, any> = {};
+  custom: any = {};
+  plugins: any[] = [];
+  getAllFunctions() { return Object.keys(this.functions || {}); }
+  getFunction(name: string) { return (this.functions || {})[name]; }
+}
+class MockServerless {
+  service: MockService = new MockService();
+  cli: any = null;
+  config: any = { servicePath: "/tmp" };
+  private _providers: Record<string, any> = {};
+  constructor(_config?: any) {}
+  setProvider(name: string, provider: any) { this._providers[name] = provider; }
+  getProvider(name: string) { return this._providers[name]; }
+  getVersion() { return "3.0.0"; }
+}
+class MockAwsProvider {
+  serverless: any;
+  options: any;
+  request: (...args: any[]) => any;
+  constructor(serverless: any, options?: any) {
+    this.serverless = serverless;
+    this.options = options || {};
+    this.request = () => Promise.resolve({});
+  }
+}
+const Serverless = MockServerless;
+const AwsProvider = MockAwsProvider;
 
 const logShim = {
     error: console.error, // tslint:disable-line


### PR DESCRIPTION
## Summary
Adds support for the New Relic Java Agent layer via a new `javaAgent` configuration option.
Previously, Java Lambdas were limited to the open-tracing layer (`NewRelicJava*`). 
This change allows users to opt into the Java Agent layer (`NewRelicAgentJava`) directly through the plugin config.

## Changes
- Introduces `javaAgent: true` config option under `custom.newRelic`
- When enabled, selects `NewRelicAgentJava` layer over the default open-tracing layer
- Automatically sets `AWS_LAMBDA_EXEC_WRAPPER=/opt/newrelic-java-handler` environment variable
- Skips handler wrapping when `javaAgent: true` — the original handler remains unchanged
- Compatible with `slim: true` to select the `NewRelicAgentJava-slim` variant

## Usage
```yaml
custom:
  newRelic:
    javaAgent: true
    slim: true  # optional
