### PR TITLE
feat: add appName config option to set NEW_RELIC_APP_NAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,18 @@ custom:
     trustedAccountKey: your-parent-account-id
 ```
 
+#### `appName` (optional)
+
+Sets the `NEW_RELIC_APP_NAME` environment variable on all instrumented functions. If not set, the plugin defaults to the function's `name` property or the function key from `serverless.yml`.
+
+You can still override this on a per-function basis by setting `NEW_RELIC_APP_NAME` directly in the function's `environment` block — that takes precedence over this config value.
+
+```yaml
+custom:
+  newRelic:
+    appName: 'my-app-name'
+```
+
 #### `debug` (optional)
 
 Whether or not to enable debug mode. Must be a boolean value. This sets the log level to

--- a/README.md
+++ b/README.md
@@ -351,13 +351,26 @@ custom:
 
 #### `slim` (optional)
 
-slim adds Node.js layer without OpenTelemetry dependencies, resulting in a lighter size.
+When set to `true`, the plugin selects a `-slim` variant of the New Relic Lambda layer if one is available for selected runtime. Slim layers omit heavier optional dependencies (such as OpenTelemetry), resulting in a smaller layer size and faster cold starts.
+
+**Node.js**: Selects the slim Node.js layer, which excludes OpenTelemetry instrumentation dependencies.
 
 ```yaml
 custom:
   newRelic:
     slim: true
 ```
+
+**Java (with `javaAgent: true`)**: Selects the slim Java Agent layer when available, reducing the layer footprint for Java functions.
+
+```yaml
+custom:
+  newRelic:
+    javaAgent: true
+    slim: true
+```
+
+If no slim layer is available for your runtime, the plugin falls back to the standard layer automatically.
 
 
 #### `cloudWatchFilter` (optional)
@@ -444,6 +457,18 @@ Defaults to `RequestHandler` interface.
 custom:
   newRelic:
     javaNewRelicHandler: handleStreamsRequest
+```
+
+#### `javaAgent` (optional)
+
+**Java runtimes only**. When set to `true`, the plugin uses the New Relic Java Agent layer (`NewRelicAgent*`) instead of the default handler wrapper layer. This sets `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/newrelic-java-handler` and leaves your function handler unchanged — no handler wrapping is applied.
+
+Use this when you want full Java APM instrumentation via the agent rather than the lightweight Lambda handler wrapper.
+
+```yaml
+custom:
+  newRelic:
+    javaAgent: true
 ```
 
 #### `proxy` (optional)

--- a/src/index.ts
+++ b/src/index.ts
@@ -537,6 +537,8 @@ or make sure that you already have Serverless 3.x installed in your project.
 
     environment.NEW_RELIC_APP_NAME = environment.NEW_RELIC_APP_NAME
       ? environment.NEW_RELIC_APP_NAME
+      : this.config.appName
+      ? String(this.config.appName)
       : name || funcName;
 
     environment.NEW_RELIC_ACCOUNT_ID = environment.NEW_RELIC_ACCOUNT_ID

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -501,6 +501,142 @@ describe("slim layer selection", () => {
     });
   });
 
+describe("appName config", () => {
+  const stage = "dev";
+  const commands: any[] = [];
+  const config = { commands, options: { stage }, log };
+
+  it("sets NEW_RELIC_APP_NAME from appName config string", async () => {
+    const serverless = new Serverless(config);
+    Object.assign(serverless.service, {
+      service: "test-service",
+      custom: {
+        newRelic: {
+          apiKey: "test-api-key",
+          accountId: "12345",
+          appName: "my-custom-app-name",
+        },
+      },
+      functions: {
+        testFunction: { handler: "index.handler", runtime: "nodejs18.x" },
+      },
+    });
+    serverless.cli = new CLI(serverless);
+    serverless.config.servicePath = os.tmpdir();
+    serverless.setProvider("aws", new AwsProvider(serverless, config));
+
+    const plugin = new NewRelicLambdaLayerPlugin(serverless, config);
+    plugin.checkForSecretPolicy = jest.fn(() => {});
+    plugin.regionPolicyValid = jest.fn(() => true);
+    plugin.configureLicenseForExtension = jest.fn(() => {});
+
+    await plugin.hooks["before:deploy:function:packageFunction"]();
+
+    expect(
+      serverless.service.functions.testFunction.environment.NEW_RELIC_APP_NAME
+    ).toBe("my-custom-app-name");
+  });
+
+  it("function-level NEW_RELIC_APP_NAME takes precedence over appName config", async () => {
+    const serverless = new Serverless(config);
+    Object.assign(serverless.service, {
+      service: "test-service",
+      custom: {
+        newRelic: {
+          apiKey: "test-api-key",
+          accountId: "12345",
+          appName: "config-app-name",
+        },
+      },
+      functions: {
+        testFunction: {
+          handler: "index.handler",
+          runtime: "nodejs18.x",
+          environment: { NEW_RELIC_APP_NAME: "function-level-app-name" },
+        },
+      },
+    });
+    serverless.cli = new CLI(serverless);
+    serverless.config.servicePath = os.tmpdir();
+    serverless.setProvider("aws", new AwsProvider(serverless, config));
+
+    const plugin = new NewRelicLambdaLayerPlugin(serverless, config);
+    plugin.checkForSecretPolicy = jest.fn(() => {});
+    plugin.regionPolicyValid = jest.fn(() => true);
+    plugin.configureLicenseForExtension = jest.fn(() => {});
+
+    await plugin.hooks["before:deploy:function:packageFunction"]();
+
+    expect(
+      serverless.service.functions.testFunction.environment.NEW_RELIC_APP_NAME
+    ).toBe("function-level-app-name");
+  });
+
+  it("function-level NEW_RELIC_ACCOUNT_ID takes precedence over accountId config", async () => {
+    const serverless = new Serverless(config);
+    Object.assign(serverless.service, {
+      service: "test-service",
+      custom: {
+        newRelic: {
+          apiKey: "test-api-key",
+          accountId: "12345",
+        },
+      },
+      functions: {
+        testFunction: {
+          handler: "index.handler",
+          runtime: "nodejs18.x",
+          environment: { NEW_RELIC_ACCOUNT_ID: "99999" },
+        },
+      },
+    });
+    serverless.cli = new CLI(serverless);
+    serverless.config.servicePath = os.tmpdir();
+    serverless.setProvider("aws", new AwsProvider(serverless, config));
+
+    const plugin = new NewRelicLambdaLayerPlugin(serverless, config);
+    plugin.checkForSecretPolicy = jest.fn(() => {});
+    plugin.regionPolicyValid = jest.fn(() => true);
+    plugin.configureLicenseForExtension = jest.fn(() => {});
+
+    await plugin.hooks["before:deploy:function:packageFunction"]();
+
+    expect(
+      serverless.service.functions.testFunction.environment.NEW_RELIC_ACCOUNT_ID
+    ).toBe("99999");
+  });
+
+  it("defaults NEW_RELIC_APP_NAME to function key when appName is not set", async () => {
+    const serverless = new Serverless(config);
+    Object.assign(serverless.service, {
+      service: "test-service",
+      custom: {
+        newRelic: {
+          apiKey: "test-api-key",
+          accountId: "12345",
+        },
+      },
+      functions: {
+        myFunction: { handler: "index.handler", runtime: "nodejs18.x" },
+      },
+    });
+    serverless.cli = new CLI(serverless);
+    serverless.config.servicePath = os.tmpdir();
+    serverless.setProvider("aws", new AwsProvider(serverless, config));
+
+    const plugin = new NewRelicLambdaLayerPlugin(serverless, config);
+    plugin.checkForSecretPolicy = jest.fn(() => {});
+    plugin.regionPolicyValid = jest.fn(() => true);
+    plugin.configureLicenseForExtension = jest.fn(() => {});
+
+    await plugin.hooks["before:deploy:function:packageFunction"]();
+
+    expect(
+      serverless.service.functions.myFunction.environment.NEW_RELIC_APP_NAME
+    ).toBe("myFunction");
+  });
+});
+
 describe("javaAgent support", () => {
   const stage = "dev";
   const commands: any[] = [];


### PR DESCRIPTION
## Summary
- Adds `appName` config option under `custom.newRelic` to set `NEW_RELIC_APP_NAME` on all instrumented functions
- Function-level `NEW_RELIC_APP_NAME` environment variable still takes precedence over the config value
- Falls back to function `name` if not is set


## Usage
```yaml
custom:
  newRelic:
    appName: 'my-app-name'